### PR TITLE
fix: column description UX and delete confirmation

### DIFF
--- a/src/providers/SemanticEditorProvider.ts
+++ b/src/providers/SemanticEditorProvider.ts
@@ -373,6 +373,14 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
             }
             break;
           }
+          case 'updateModelDescription': {
+            const payload = (message as { payload?: { modelName: string; description: string } }).payload;
+            if (payload) {
+              await this.queueEdit(panelKey, () =>
+                this.handleUpdateModelDescription(document, webviewPanel.webview, payload, activeStage));
+            }
+            break;
+          }
           case 'updateModelGrain': {
             const payload = (message as { payload?: { modelName: string; grain: string } }).payload;
             if (payload) {
@@ -2103,6 +2111,48 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[SemanticEditorProvider] Update design rationale failed: ${message}`);
       webview.postMessage({ type: 'error', payload: { message: `Failed to update design rationale: ${message}` } });
+    }
+  }
+
+  private async handleUpdateModelDescription(
+    document: vscode.TextDocument,
+    webview: vscode.Webview,
+    payload: { modelName: string; description: string },
+    stage: 'logical',
+  ): Promise<void> {
+    try {
+      // V5: write to central model file
+      const text = document.getText();
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      if (this.isDomainV5(parsed)) {
+        await this.applyModelEdit(document, webview, payload.modelName, (model) => {
+          const description = payload.description?.trim() || undefined;
+          if (description) { model.description = description; } else { delete model.description; }
+        });
+        return;
+      }
+
+      // V4: legacy inline path
+      const success = await this.applyDomainEdit(
+        document,
+        (section) => {
+          const models = (section.models ?? []) as Array<Record<string, unknown>>;
+          const model = models.find((m) => m.name === payload.modelName);
+          if (!model) { throw new Error(`Model "${payload.modelName}" not found.`); }
+
+          const description = payload.description?.trim() || undefined;
+          if (description) { model.description = description; } else { delete model.description; }
+        },
+        { webview, stage },
+      );
+
+      if (!success) {
+        webview.postMessage({ type: 'error', payload: { message: 'Failed to update description.' } });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[SemanticEditorProvider] Update description failed: ${message}`);
+      webview.postMessage({ type: 'error', payload: { message: `Failed to update description: ${message}` } });
     }
   }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -338,6 +338,18 @@ export interface UpdateModelRationaleMessage {
 }
 
 /**
+ * Request to update the description for a model.
+ * If the description is empty/cleared, the `description` key is removed from the JSON entirely.
+ */
+export interface UpdateModelDescriptionMessage {
+  type: 'updateModelDescription';
+  payload: {
+    modelName: string;
+    description: string;
+  };
+}
+
+/**
  * Request to update the grain statement for a model.
  * If the grain is empty/cleared, the `grain` key is removed from the JSON entirely.
  */
@@ -482,6 +494,7 @@ export type WebviewMessage =
   | RedoMessage
   | ToggleColumnKeyMessage
   | UpdateModelRationaleMessage
+  | UpdateModelDescriptionMessage
   | UpdateModelGrainMessage
   | UpdateModelRoleMessage
   | ToggleStubColumnsMessage

--- a/webview/components/DetailPanel/ColumnEditor.tsx
+++ b/webview/components/DetailPanel/ColumnEditor.tsx
@@ -118,17 +118,30 @@ export function ColumnEditor({ modelName, columns, readOnly, modelRole }: Column
   }, []);
 
   // Handle toggling a single column's expanded state
-  const handleToggleExpand = useCallback((columnName: string) => {
-    setExpandedColumns((prev) => {
-      const next = new Set(prev);
-      if (next.has(columnName)) {
-        next.delete(columnName);
-      } else {
-        next.add(columnName);
-      }
-      return next;
-    });
-  }, []);
+  const handleToggleExpand = useCallback((columnName: string, opts?: { altKey?: boolean }) => {
+    if (opts?.altKey) {
+      // Alt+Click: expand all if this column was collapsed, collapse all if it was expanded
+      setExpandedColumns((prev) => {
+        if (prev.has(columnName)) {
+          // Column was expanded → collapse all
+          return new Set();
+        } else {
+          // Column was collapsed → expand all
+          return new Set(columns.map((c) => c.name));
+        }
+      });
+    } else {
+      setExpandedColumns((prev) => {
+        const next = new Set(prev);
+        if (next.has(columnName)) {
+          next.delete(columnName);
+        } else {
+          next.add(columnName);
+        }
+        return next;
+      });
+    }
+  }, [columns]);
 
   // Expand all columns
   const handleExpandAll = useCallback(() => {
@@ -282,7 +295,7 @@ export function ColumnEditor({ modelName, columns, readOnly, modelRole }: Column
             showMultiplePKWarning={hasMultiplePKs && col.isPrimaryKey}
             modelRole={modelRole}
             expanded={expandedColumns.has(col.name)}
-            onToggleExpand={() => handleToggleExpand(col.name)}
+            onToggleExpand={(opts) => handleToggleExpand(col.name, opts)}
             dragHandleProps={isEditable ? getDragHandleProps(idx) : undefined}
             isDragOver={dropIndex === idx && dragIndex !== idx}
             isBeingDragged={dragIndex === idx}

--- a/webview/components/DetailPanel/ColumnEditor.tsx
+++ b/webview/components/DetailPanel/ColumnEditor.tsx
@@ -117,19 +117,21 @@ export function ColumnEditor({ modelName, columns, readOnly, modelRole }: Column
     setIsAddingColumn(false);
   }, []);
 
+  // Expand all columns
+  const handleExpandAll = useCallback(() => {
+    setExpandedColumns(new Set(columns.map((c) => c.name)));
+  }, [columns]);
+
+  // Collapse all columns
+  const handleCollapseAll = useCallback(() => {
+    setExpandedColumns(new Set());
+  }, []);
+
   // Handle toggling a single column's expanded state
   const handleToggleExpand = useCallback((columnName: string, opts?: { altKey?: boolean }) => {
     if (opts?.altKey) {
       // Alt+Click: expand all if this column was collapsed, collapse all if it was expanded
-      setExpandedColumns((prev) => {
-        if (prev.has(columnName)) {
-          // Column was expanded → collapse all
-          return new Set();
-        } else {
-          // Column was collapsed → expand all
-          return new Set(columns.map((c) => c.name));
-        }
-      });
+      setExpandedColumns((prev) => prev.has(columnName) ? new Set() : new Set(columns.map((c) => c.name)));
     } else {
       setExpandedColumns((prev) => {
         const next = new Set(prev);
@@ -142,16 +144,6 @@ export function ColumnEditor({ modelName, columns, readOnly, modelRole }: Column
       });
     }
   }, [columns]);
-
-  // Expand all columns
-  const handleExpandAll = useCallback(() => {
-    setExpandedColumns(new Set(columns.map((c) => c.name)));
-  }, [columns]);
-
-  // Collapse all columns
-  const handleCollapseAll = useCallback(() => {
-    setExpandedColumns(new Set());
-  }, []);
 
   // Prune stale selections when columns change (e.g. column deleted externally)
   useEffect(() => {

--- a/webview/components/DetailPanel/DescriptionEditor.tsx
+++ b/webview/components/DetailPanel/DescriptionEditor.tsx
@@ -1,0 +1,132 @@
+/**
+ * DescriptionEditor — displays and edits the description for a model.
+ *
+ * Three states:
+ * 1. Empty — dashed "Add Description" button when no content exists
+ * 2. Read — shows description text with pencil edit button on hover
+ * 3. Edit — textarea with Save/Cancel buttons
+ *
+ * Follows the same pattern as GrainEditor.tsx.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useVsCodeApi } from '../../hooks/useVsCodeApi';
+
+interface DescriptionEditorProps {
+  modelName: string;
+  description?: string;
+}
+
+export function DescriptionEditor({ modelName, description }: DescriptionEditorProps) {
+  const vscode = useVsCodeApi();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(description ?? '');
+
+  // Sync from props when not editing (e.g. domain refresh from extension host)
+  useEffect(() => {
+    if (!editing) {
+      setValue(description ?? '');
+    }
+  }, [description, editing]);
+
+  const hasContent = !!description;
+
+  const handleSave = useCallback(() => {
+    const trimmed = value.trim();
+    // Skip no-op saves to avoid spurious undo entries
+    if (trimmed === (description ?? '')) {
+      setEditing(false);
+      return;
+    }
+    vscode.postMessage({
+      type: 'updateModelDescription',
+      payload: { modelName, description: trimmed },
+    });
+    setEditing(false);
+  }, [vscode, modelName, value, description]);
+
+  const handleCancel = useCallback(() => {
+    setValue(description ?? '');
+    setEditing(false);
+  }, [description]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleCancel],
+  );
+
+  // --- Empty state ---
+  if (!hasContent && !editing) {
+    return (
+      <div className="detail-panel__description-section">
+        <button
+          className="detail-panel__rationale-add-btn"
+          onClick={() => setEditing(true)}
+          title="Add model description"
+        >
+          + Add Description
+        </button>
+      </div>
+    );
+  }
+
+  // --- Edit mode ---
+  if (editing) {
+    return (
+      <div className="detail-panel__description-section">
+        <div className="detail-panel__rationale-header">
+          <h4 className="detail-panel__section-title" style={{ margin: 0 }}>
+            Description
+          </h4>
+        </div>
+        <textarea
+          className="detail-panel__rationale-textarea"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Describe this model..."
+          rows={3}
+          autoFocus
+        />
+        <div className="detail-panel__rationale-actions">
+          <button className="detail-panel__button" onClick={handleSave}>
+            Save
+          </button>
+          <button className="detail-panel__button" onClick={handleCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Read mode ---
+  return (
+    <div className="detail-panel__description-section">
+      <div className="detail-panel__rationale-header">
+        <h4 className="detail-panel__section-title" style={{ margin: 0 }}>
+          Description
+        </h4>
+        <button
+          className="detail-panel__rationale-edit-btn"
+          onClick={() => setEditing(true)}
+          title="Edit description"
+          aria-label="Edit description"
+        >
+          ✎
+        </button>
+      </div>
+      <div
+        className="detail-panel__rationale-field"
+        onDoubleClick={() => setEditing(true)}
+      >
+        <p className="detail-panel__rationale-text">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/webview/components/DetailPanel/DetailPanel.tsx
+++ b/webview/components/DetailPanel/DetailPanel.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Panel } from '@xyflow/react';
 
 import { ModelRationale } from './ModelRationale';
+import { DescriptionEditor } from './DescriptionEditor';
 import { GrainEditor } from './GrainEditor';
 import { RoleEditor } from './RoleEditor';
 import { ColumnEditor } from './ColumnEditor';
@@ -261,8 +262,12 @@ export function DetailPanel() {
             <span className="detail-panel__value">{model.schema || '—'}</span>
           </div>
         </div>
-        {model.description && (
-          <p className="detail-panel__description">{model.description}</p>
+        {isReadOnly ? (
+          model.description && (
+            <p className="detail-panel__description">{model.description}</p>
+          )
+        ) : (
+          <DescriptionEditor modelName={model.name} description={model.description} />
         )}
       </div>
 

--- a/webview/components/common/ColumnRowEditor.css
+++ b/webview/components/common/ColumnRowEditor.css
@@ -36,12 +36,20 @@
   background: rgba(34, 197, 94, 0.15);
 }
 
+.column-row-editor--built.column-row-editor--expanded:hover .column-row-editor__main {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .column-row-editor--planned .column-row-editor__main {
   background: var(--model-design-bg);
 }
 
 .column-row-editor--planned:hover .column-row-editor__main {
   background: rgba(249, 115, 22, 0.15);
+}
+
+.column-row-editor--planned.column-row-editor--expanded:hover .column-row-editor__main {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .column-row-editor--approved .column-row-editor__main {
@@ -178,6 +186,58 @@
 
 .column-row-editor__delete:hover {
   background: rgba(239, 68, 68, 0.25);
+}
+
+/* Delete confirmation inline */
+.column-row-editor__delete-confirm {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  animation: delete-confirm-fade-in 0.15s ease;
+}
+
+@keyframes delete-confirm-fade-in {
+  from { opacity: 0; transform: translateX(4px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.column-row-editor__delete-confirm-yes {
+  padding: 1px 6px;
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  border-radius: 3px;
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s ease;
+}
+
+.column-row-editor__delete-confirm-yes:hover {
+  background: rgba(239, 68, 68, 0.3);
+}
+
+.column-row-editor__delete-confirm-no {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vscode-descriptionForeground, #888);
+  font-size: 10px;
+  cursor: pointer;
+  transition: color 0.1s ease, background 0.1s ease;
+}
+
+.column-row-editor__delete-confirm-no:hover {
+  color: var(--editor-fg);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* ---------------------------------------------------------------------------
@@ -325,8 +385,9 @@
 }
 
 .column-row-editor__description-text--empty {
-  color: var(--vscode-descriptionForeground, #888);
+  color: var(--vscode-descriptionForeground, #999);
   font-style: italic;
+  opacity: 0.8;
 }
 
 .column-row-editor__description-input {

--- a/webview/components/common/ColumnRowEditor.css
+++ b/webview/components/common/ColumnRowEditor.css
@@ -36,10 +36,6 @@
   background: rgba(34, 197, 94, 0.15);
 }
 
-.column-row-editor--built.column-row-editor--expanded:hover .column-row-editor__main {
-  background: rgba(255, 255, 255, 0.06);
-}
-
 .column-row-editor--planned .column-row-editor__main {
   background: var(--model-design-bg);
 }
@@ -48,6 +44,8 @@
   background: rgba(249, 115, 22, 0.15);
 }
 
+/* Suppress colored hover tint when description is expanded — use neutral background */
+.column-row-editor--built.column-row-editor--expanded:hover .column-row-editor__main,
 .column-row-editor--planned.column-row-editor--expanded:hover .column-row-editor__main {
   background: rgba(255, 255, 255, 0.06);
 }
@@ -207,7 +205,7 @@
   border: 1px solid rgba(239, 68, 68, 0.5);
   border-radius: 3px;
   background: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
+  color: var(--vscode-errorForeground, #f48771);
   font-size: 10px;
   font-weight: 600;
   cursor: pointer;
@@ -385,9 +383,8 @@
 }
 
 .column-row-editor__description-text--empty {
-  color: var(--vscode-descriptionForeground, #999);
+  color: var(--vscode-descriptionForeground, #888);
   font-style: italic;
-  opacity: 0.8;
 }
 
 .column-row-editor__description-input {

--- a/webview/components/common/ColumnRowEditor.tsx
+++ b/webview/components/common/ColumnRowEditor.tsx
@@ -667,7 +667,7 @@ export function ColumnRowEditor({
               title={mode !== 'readonly' ? 'Click to edit description' : undefined}
             >
               {localColumn.description || (
-                mode !== 'readonly' ? '\u270F Add description...' : 'No description'
+                mode !== 'readonly' ? '✏ Add description...' : 'No description'
               )}
             </div>
           )}

--- a/webview/components/common/ColumnRowEditor.tsx
+++ b/webview/components/common/ColumnRowEditor.tsx
@@ -63,7 +63,7 @@ export interface ColumnRowEditorProps {
   /** Whether the description area is expanded. */
   expanded?: boolean;
   /** Callback when the expand/collapse chevron is clicked. */
-  onToggleExpand?: () => void;
+  onToggleExpand?: (opts?: { altKey?: boolean }) => void;
   /** Props to spread onto a drag handle element for reordering. */
   dragHandleProps?: React.HTMLAttributes<HTMLSpanElement>;
   /** Whether a dragged row is currently hovering above this row. */
@@ -148,6 +148,10 @@ export function ColumnRowEditor({
     mode === 'new' ? 'name' : null
   );
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  // Ref for delete confirmation auto-dismiss timer
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Refs for auto-focus
   const nameInputRef = useRef<HTMLInputElement>(null);
@@ -190,6 +194,13 @@ export function ColumnRowEditor({
     column.scdType,
     column.additiveType,
   ]);
+
+  // Cleanup delete confirmation timer on unmount
+  useEffect(() => {
+    return () => {
+      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    };
+  }, []);
 
   // Enter edit mode when store signals via isEditingActive (F2 key)
   useEffect(() => {
@@ -360,13 +371,34 @@ export function ColumnRowEditor({
     [mode, localColumn, existingColumnNames, column.name, onUpdate]
   );
 
-  // Handle delete click
+  // Handle delete click — two-click confirmation
   const handleDeleteClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      onDelete?.();
+      if (confirmingDelete) {
+        // Second click confirms deletion
+        if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+        setConfirmingDelete(false);
+        onDelete?.();
+      } else {
+        // First click enters confirmation state
+        setConfirmingDelete(true);
+        // Auto-dismiss after 3 seconds
+        deleteTimerRef.current = setTimeout(() => {
+          setConfirmingDelete(false);
+        }, 3000);
+      }
     },
-    [onDelete]
+    [confirmingDelete, onDelete]
+  );
+
+  const handleCancelDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+      setConfirmingDelete(false);
+    },
+    []
   );
 
   // Handle SCD type change — auto-saves immediately
@@ -422,7 +454,7 @@ export function ColumnRowEditor({
   const handleChevronClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      onToggleExpand?.();
+      onToggleExpand?.({ altKey: e.altKey });
     },
     [onToggleExpand]
   );
@@ -486,7 +518,7 @@ export function ColumnRowEditor({
           <button
             className="column-row-editor__chevron"
             onClick={handleChevronClick}
-            title={expanded ? 'Collapse description' : 'Expand description'}
+            title={expanded ? 'Collapse description (Alt+Click: all)' : 'Expand description (Alt+Click: all)'}
             aria-label={expanded ? 'Collapse description' : 'Expand description'}
             aria-expanded={expanded}
           >
@@ -570,14 +602,35 @@ export function ColumnRowEditor({
 
         {/* Delete button */}
         {showDelete && mode !== 'readonly' && mode !== 'new' && (
-          <button
-            className="column-row-editor__delete"
-            onClick={handleDeleteClick}
-            title="Delete column"
-            aria-label="Delete column"
-          >
-            ×
-          </button>
+          confirmingDelete ? (
+            <span className="column-row-editor__delete-confirm">
+              <button
+                className="column-row-editor__delete-confirm-yes"
+                onClick={handleDeleteClick}
+                title="Confirm delete"
+                aria-label="Confirm delete column"
+              >
+                Delete?
+              </button>
+              <button
+                className="column-row-editor__delete-confirm-no"
+                onClick={handleCancelDelete}
+                title="Cancel"
+                aria-label="Cancel delete"
+              >
+                ✕
+              </button>
+            </span>
+          ) : (
+            <button
+              className="column-row-editor__delete"
+              onClick={handleDeleteClick}
+              title="Delete column"
+              aria-label="Delete column"
+            >
+              ×
+            </button>
+          )
         )}
       </div>
 
@@ -610,11 +663,11 @@ export function ColumnRowEditor({
           ) : (
             <div
               className={`column-row-editor__description-text ${!hasDescription ? 'column-row-editor__description-text--empty' : ''}`}
-              onDoubleClick={() => handleFieldClick('description')}
-              title={mode !== 'readonly' ? 'Double-click to edit description' : undefined}
+              onClick={() => handleFieldClick('description')}
+              title={mode !== 'readonly' ? 'Click to edit description' : undefined}
             >
               {localColumn.description || (
-                mode !== 'readonly' ? 'Click to add description...' : 'No description'
+                mode !== 'readonly' ? '\u270F Add description...' : 'No description'
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Suppress orange/green hover tint when column description is expanded — uses neutral background instead
- Change description editing from double-click to single-click with ✏ pencil icon placeholder
- Add Alt+Click on column chevron to expand/collapse all descriptions at once
- Add inline "Delete?" confirmation before column removal (3s auto-dismiss) to prevent accidental deletions

## Test plan
- [ ] Expand a column description → hover the row → should NOT show orange/green tint
- [ ] Click "✏ Add description..." on an empty column → should enter edit mode immediately (single click)
- [ ] Alt+Click any column chevron → all columns should expand/collapse together
- [ ] Click × on a column → should show "Delete?" confirmation inline, not delete immediately
- [ ] Wait 3s without confirming → confirmation should auto-dismiss
- [ ] Click "Delete?" to confirm → column should be removed
- [ ] Cmd+Z after delete → column should be restored via undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)