### PR TITLE
feat: replace PAT auth with GitHub OAuth via Forge External Auth

### DIFF
--- a/forge-app/manifest.yml
+++ b/forge-app/manifest.yml
@@ -12,12 +12,51 @@ modules:
   function:
     - key: resolver
       handler: index.handler
+      providers:
+        auth:
+          - github
+providers:
+  auth:
+    - key: github
+      name: GitHub
+      type: oauth2
+      clientId: Ov23ctA25E7CrdmLZXpv
+      scopes:
+        - repo
+      remotes:
+        - github-api
+      bearerMethod:
+        type: authorization-header
+      actions:
+        authorization:
+          remote: github-main
+          path: /login/oauth/authorize
+        exchange:
+          remote: github-main
+          path: /login/oauth/access_token
+          resolvers:
+            accessToken: access_token
+          overrides:
+            headers:
+              Accept: application/json
+        retrieveProfile:
+          remote: github-api
+          path: /user
+          resolvers:
+            id: id
+            displayName: login
+            avatarUrl: avatar_url
 app:
   runtime:
     name: nodejs24.x
     memoryMB: 256
     architecture: arm64
   id: ari:cloud:ecosystem::app/aa70d9de-2e23-4be4-94fa-6a24740dde2d
+remotes:
+  - key: github-main
+    baseUrl: https://github.com
+  - key: github-api
+    baseUrl: https://api.github.com
 resources:
   - key: main-resource
     path: static/frontend/build
@@ -33,5 +72,5 @@ permissions:
   external:
     fetch:
       backend:
-        - raw.githubusercontent.com
-        - api.github.com
+        - 'https://github.com'
+        - 'https://api.github.com'

--- a/forge-app/package-lock.json
+++ b/forge-app/package-lock.json
@@ -10,50 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@forge/api": "^7.1.1",
-        "@forge/resolver": "1.7.1"
+        "@forge/kvs": "^1.5.0",
+        "@forge/resolver": "^1.7.1",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "eslint": "^8.56.0",
         "eslint-plugin-react-hooks": "^4.6.0"
-      }
-    },
-    "../../../../node_modules/@atlassian/metrics-interface": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "Proprietary"
-    },
-    "../../../../node_modules/@types/jest": {
-      "version": "29.5.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
-    "../../../../node_modules/@types/node": {
-      "version": "20.19.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "../../../../node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "../../../../node_modules/@types/node-fetch/node_modules/@types/node": {
-      "version": "20.11.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "../../../../node_modules/@types/ws": {
@@ -356,139 +319,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../node_modules/expect-type": {
-      "version": "0.17.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "@types/jest": "29.0.0",
-        "@types/node": "^14.0.0",
-        "eslint": "8.23.0",
-        "eslint-plugin-mmkal": "0.0.1-2",
-        "jest": "28.1.3",
-        "np": "^8.0.4",
-        "strip-ansi": "6.0.1",
-        "ts-jest": "28.0.8",
-        "ts-morph": "16.0.0",
-        "typescript": "4.8.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "../../../../node_modules/express": {
-      "version": "4.21.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "devDependencies": {
-        "after": "0.8.2",
-        "connect-redis": "3.4.2",
-        "cookie-parser": "1.4.6",
-        "cookie-session": "2.0.0",
-        "ejs": "3.1.9",
-        "eslint": "8.47.0",
-        "express-session": "1.17.2",
-        "hbs": "4.2.0",
-        "marked": "0.7.0",
-        "method-override": "3.0.0",
-        "mocha": "10.2.0",
-        "morgan": "1.10.0",
-        "nyc": "15.1.0",
-        "pbkdf2-password": "1.2.1",
-        "supertest": "6.3.0",
-        "vhost": "~3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "../../../../node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "../../../../node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../../../node_modules/express/node_modules/qs": {
-      "version": "6.11.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "../../../../node_modules/express/node_modules/statuses": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "../../../../node_modules/fp-ts": {
       "version": "2.16.2",
       "extraneous": true,
       "license": "MIT"
-    },
-    "../../../../node_modules/headers-utils": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/jest": "^26.0.20",
-        "jest": "^26.6.3",
-        "rimraf": "^3.0.2",
-        "ts-jest": "^26.5.3",
-        "typescript": "^4.2.3"
-      }
     },
     "../../../../node_modules/io-ts": {
       "version": "2.2.21",
@@ -525,35 +359,6 @@
         "io-ts": "^2.2.16"
       }
     },
-    "../../../../node_modules/jest": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "import-local": "^3.0.2",
-        "jest-cli": "^29.7.0"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "devDependencies": {
-        "@tsd/typescript": "^5.0.4",
-        "tsd-lite": "^0.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
     "../../../../node_modules/jest-junit": {
       "version": "16.0.0",
       "extraneous": true,
@@ -572,34 +377,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "../../../../node_modules/jest-matcher-specific-error": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@types/jest": "^26.0.14",
-        "@types/node": "^14.11.2",
-        "@types/strip-color": "^0.1.0",
-        "@typescript-eslint/eslint-plugin": "^4.3.0",
-        "@typescript-eslint/parser": "^4.3.0",
-        "eslint": "^7.10.0",
-        "eslint-config-prettier": "^6.12.0",
-        "eslint-plugin-filenames": "^1.3.2",
-        "eslint-plugin-jest": "^24.0.2",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "eslint-plugin-simple-import-sort": "^5.0.3",
-        "jest": "^26.4.2",
-        "prettier": "^2.1.2",
-        "strip-color": "^0.1.0",
-        "ts-jest": "^26.4.1",
-        "typescript": "^4.0.3"
-      }
-    },
-    "../../../../node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
     },
     "../../../../node_modules/minimatch": {
       "version": "9.0.5",
@@ -626,46 +403,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "../../../../node_modules/nock": {
-      "version": "13.5.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "devDependencies": {
-        "@definitelytyped/dtslint": "^0.0.163",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "assert-rejects": "^1.0.0",
-        "chai": "^4.1.2",
-        "dirty-chai": "^2.0.1",
-        "eslint": "^8.8.0",
-        "eslint-config-prettier": "^9.0.0",
-        "eslint-config-standard": "^17.0.0-0",
-        "eslint-plugin-import": "^2.16.0",
-        "eslint-plugin-mocha": "^10.0.3",
-        "eslint-plugin-node": "^11.0.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "form-data": "^4.0.0",
-        "got": "^11.3.0",
-        "jest": "^29.7.0",
-        "mocha": "^9.1.3",
-        "npm-run-all": "^4.1.5",
-        "nyc": "^15.0.0",
-        "prettier": "3.2.5",
-        "proxyquire": "^2.1.0",
-        "rimraf": "^3.0.0",
-        "semantic-release": "^24.1.0",
-        "sinon": "^15.0.1",
-        "sinon-chai": "^3.7.0",
-        "typescript": "^5.0.4"
-      },
-      "engines": {
-        "node": ">= 10.13"
       }
     },
     "../../../../node_modules/node-fetch": {
@@ -877,10 +614,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "../../../../node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
-    },
     "../../../../node_modules/typescript": {
       "version": "4.8.4",
       "extraneous": true,
@@ -1066,177 +799,6 @@
         "node": ">= 14"
       }
     },
-    "../../../forge-api": {
-      "name": "@forge/api",
-      "version": "7.1.1",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "@forge/auth": "0.0.9",
-        "@forge/egress": "2.3.1",
-        "@forge/i18n": "0.0.7",
-        "@forge/manifest": "^12.3.0",
-        "@forge/storage": "2.0.3",
-        "headers-utils": "^3.0.2"
-      },
-      "devDependencies": {
-        "@atlassian/ari": "^2.199.0",
-        "@atlassian/in-memory-metrics": "0.1.0",
-        "@atlassian/metrics-interface": "4.0.0",
-        "@forge/runtime": "6.1.2",
-        "@types/node": "20.19.1",
-        "@types/node-fetch": "^2.6.12",
-        "expect-type": "^0.17.3",
-        "express": "^4.18.3",
-        "jest-matcher-specific-error": "^1.0.0",
-        "nock": "13.5.6"
-      }
-    },
-    "../../../forge-api/node_modules/@forge/auth": {
-      "resolved": "../../../forge-auth",
-      "link": true
-    },
-    "../../../forge-api/node_modules/@forge/egress": {
-      "resolved": "../../../forge-egress",
-      "link": true
-    },
-    "../../../forge-api/node_modules/@forge/i18n": {
-      "resolved": "../../../forge-i18n",
-      "link": true
-    },
-    "../../../forge-api/node_modules/@forge/runtime": {
-      "resolved": "../../../forge-runtime",
-      "link": true
-    },
-    "../../../forge-api/node_modules/@forge/storage": {
-      "resolved": "../../../forge-storage",
-      "link": true
-    },
-    "../../../forge-api/node_modules/@types/node": {
-      "resolved": "../../../../node_modules/@types/node",
-      "link": true
-    },
-    "../../../forge-api/node_modules/@types/node-fetch": {
-      "resolved": "../../../../node_modules/@types/node-fetch",
-      "link": true
-    },
-    "../../../forge-api/node_modules/expect-type": {
-      "resolved": "../../../../node_modules/expect-type",
-      "link": true
-    },
-    "../../../forge-api/node_modules/express": {
-      "resolved": "../../../../node_modules/express",
-      "link": true
-    },
-    "../../../forge-api/node_modules/headers-utils": {
-      "resolved": "../../../../node_modules/headers-utils",
-      "link": true
-    },
-    "../../../forge-api/node_modules/jest-matcher-specific-error": {
-      "resolved": "../../../../node_modules/jest-matcher-specific-error",
-      "link": true
-    },
-    "../../../forge-api/node_modules/nock": {
-      "resolved": "../../../../node_modules/nock",
-      "link": true
-    },
-    "../../../forge-auth": {
-      "name": "@forge/auth",
-      "version": "0.0.9",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "../../../forge-auth/node_modules/tslib": {
-      "resolved": "../../../../node_modules/tslib",
-      "link": true
-    },
-    "../../../forge-egress": {
-      "name": "@forge/egress",
-      "version": "2.3.1",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "devDependencies": {
-        "@types/jest": "^29.5.14",
-        "@types/node": "20.19.1"
-      }
-    },
-    "../../../forge-egress/node_modules/@types/jest": {
-      "resolved": "../../../../node_modules/@types/jest",
-      "link": true
-    },
-    "../../../forge-egress/node_modules/@types/node": {
-      "resolved": "../../../../node_modules/@types/node",
-      "link": true
-    },
-    "../../../forge-i18n": {
-      "name": "@forge/i18n",
-      "version": "0.0.7",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.14",
-        "jest": "^29.7.0"
-      }
-    },
-    "../../../forge-i18n/node_modules/@types/jest": {
-      "resolved": "../../../../node_modules/@types/jest",
-      "link": true
-    },
-    "../../../forge-i18n/node_modules/jest": {
-      "resolved": "../../../../node_modules/jest",
-      "link": true
-    },
-    "../../../forge-i18n/node_modules/lodash": {
-      "resolved": "../../../../node_modules/lodash",
-      "link": true
-    },
-    "../../../forge-resolver": {
-      "name": "@forge/resolver",
-      "version": "1.7.1",
-      "license": "SEE LICENSE IN LICENSE.txt"
-    },
-    "../../../forge-runtime": {
-      "name": "@forge/runtime",
-      "version": "6.1.2",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "devDependencies": {
-        "@types/jest": "^29.5.14",
-        "@types/node": "20.19.1",
-        "jest": "^29.7.0"
-      }
-    },
-    "../../../forge-runtime/node_modules/@types/jest": {
-      "resolved": "../../../../node_modules/@types/jest",
-      "link": true
-    },
-    "../../../forge-runtime/node_modules/@types/node": {
-      "resolved": "../../../../node_modules/@types/node",
-      "link": true
-    },
-    "../../../forge-runtime/node_modules/jest": {
-      "resolved": "../../../../node_modules/jest",
-      "link": true
-    },
-    "../../../forge-storage": {
-      "name": "@forge/storage",
-      "version": "2.0.3",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "devDependencies": {
-        "@atlassian/metrics-interface": "4.0.0",
-        "@types/node": "20.19.1"
-      }
-    },
-    "../../../forge-storage/node_modules/@atlassian/metrics-interface": {
-      "resolved": "../../../../node_modules/@atlassian/metrics-interface",
-      "link": true
-    },
-    "../../../forge-storage/node_modules/@types/node": {
-      "resolved": "../../../../node_modules/@types/node",
-      "link": true
-    },
     "../../../forge-util": {
       "name": "@forge/util",
       "version": "2.0.0-next.0",
@@ -1247,12 +809,353 @@
       }
     },
     "node_modules/@forge/api": {
-      "resolved": "../../../forge-api",
-      "link": true
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@forge/api/-/api-7.1.1.tgz",
+      "integrity": "sha512-OYaiNlP/oDjVrwwEmOj3LbcV2NgyQv0l14d6YsqlCusxaif1t96ArgUj3BMha/jvEINsgIq52RLUgUqRqBvJmQ==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@forge/auth": "0.0.9",
+        "@forge/egress": "2.3.1",
+        "@forge/i18n": "0.0.7",
+        "@forge/manifest": "^12.3.0",
+        "@forge/storage": "2.0.3",
+        "headers-utils": "^3.0.2"
+      }
+    },
+    "node_modules/@forge/auth": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@forge/auth/-/auth-0.0.9.tgz",
+      "integrity": "sha512-3qZZNknFprzDkrXzBVKHqVD12r/b2K9cu/RJh9TP3QLiF18v7bdoD1fgZZbVavKJUmCNdQERk6NTVQLmmEszhg==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@forge/egress": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@forge/egress/-/egress-2.3.1.tgz",
+      "integrity": "sha512-NoqQsoPj98F8yBJyUUy72PEdcqvJo7upGWTllZ6RN3ZAxvmq2jnCrJ+ipVBYqTIHJLhKNc2PKxRpBls7NQA20A==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
+    "node_modules/@forge/i18n": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@forge/i18n/-/i18n-0.0.7.tgz",
+      "integrity": "sha512-EKrQApcuI4k4AkUSeERkZv1dQaGjWsmB8i7ciDPtpDARPRH1sOrU+FSEOoA7b9FQ15++7Q144m94w/aMLCg5Gg==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@forge/kvs": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@forge/kvs/-/kvs-1.5.0.tgz",
+      "integrity": "sha512-RFrI7I0VrnvihaIWF7p8ZIUvuuackuZjnSG/sD2buNo2fQSAfvbJh5qXczStXfiFI0A+AcDbgnzOLPC4oP5KGA==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@forge/api": "^7.1.1"
+      }
+    },
+    "node_modules/@forge/manifest": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-12.3.0.tgz",
+      "integrity": "sha512-4yBKiSr9sL7mfDKJ0RPEnyGROrEHbsrAIX9YxJY4zGMCJDKAE2gwRR+BgJBHnffDwMoW8t0ggCg+TFpRehNhfw==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@forge/i18n": "0.0.7",
+        "@sentry/node": "7.106.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "2.1.1",
+        "cheerio": "^1.1.0",
+        "glob": "^13.0.0",
+        "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
+        "yaml": "^2.3.4"
+      }
     },
     "node_modules/@forge/resolver": {
-      "resolved": "../../../forge-resolver",
-      "link": true
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@forge/resolver/-/resolver-1.7.1.tgz",
+      "integrity": "sha512-xZUeAZSG1c4Fu05uXAze9pnZHqQ4fnfdkSaYKQjYNrj8Yo3FgkFKQ/WZ+K2iNDYsZk2s9UN3Vs3RtR1BVCFACg==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
+    "node_modules/@forge/storage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@forge/storage/-/storage-2.0.3.tgz",
+      "integrity": "sha512-DvliHUgr9AYPslpFWBB4LufS8yzvJisqfpP+CCAwo76xBWNlXWFd3PRFA/DaZeGz+Vb4vmBYP7qFMqM1oijIrQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.106.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.106.0.tgz",
+      "integrity": "sha512-O8Es6Sa/tP80nfl+8soNfWzeRNFcT484SvjLR8BS3pHM9KDAlwNXyoQhFr2BKNYL1irbq6UF6eku4xCnUKVmqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.106.0",
+        "@sentry/types": "7.106.0",
+        "@sentry/utils": "7.106.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.106.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.106.0.tgz",
+      "integrity": "sha512-Dc13XtnyFaXup2E4vCbzuG0QKAVjrJBk4qfGwvSJaTuopEaEWBs2MpK6hRzFhsz9S3T0La7c1F/62NptvTUWsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.106.0",
+        "@sentry/utils": "7.106.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.106.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.106.0.tgz",
+      "integrity": "sha512-4DIqbu5K7//lK/k2nV8lqKeGQzhu2T1OpJFmiUrjN6fUKWivGFjZrcmQDS7tvhAAyJezkL3LlrNU4tjPHUElPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.106.0",
+        "@sentry/core": "7.106.0",
+        "@sentry/types": "7.106.0",
+        "@sentry/utils": "7.106.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.106.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.106.0.tgz",
+      "integrity": "sha512-oKTkDaL6P9xJC5/zHLRemHTWboUqRYjkJNaZCN63j4kJqGy56wee4vDtDese/NWWn4U4C1QV1h+Mifm2HmDcQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.106.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.106.0.tgz",
+      "integrity": "sha512-bVsePsXLpFu/1sH4rpJrPcnVxW2fXXfGfGxKs6Bm+dkOMbuVTlk/KAzIbdjCDIpVlrMDJmMNEv5xgTFjgWDkjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.106.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/eslint": {
       "resolved": "../../../../node_modules/eslint",
@@ -1261,6 +1164,304 @@
     "node_modules/eslint-plugin-react-hooks": {
       "resolved": "../../../../node_modules/eslint-plugin-react-hooks",
       "link": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/headers-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
+      "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/forge-app/package.json
+++ b/forge-app/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@forge/api": "^7.1.1",
-    "@forge/resolver": "1.7.1"
+    "@forge/kvs": "^1.5.0",
+    "@forge/resolver": "^1.7.1",
+    "tslib": "^2.8.1"
   }
 }

--- a/forge-app/src/resolvers/index.js
+++ b/forge-app/src/resolvers/index.js
@@ -1,21 +1,35 @@
 import Resolver from '@forge/resolver';
-import { fetch } from '@forge/api';
-import { storage } from '@forge/api';
+import api from '@forge/api';
+import { kvs as storage } from '@forge/kvs';
 
 const resolver = new Resolver();
 
-// Helper: fetch a file from GitHub via API (supports private repos)
-async function fetchGitHubFile(repo, branch, path, token) {
-  // Use GitHub Contents API — works for both public and private repos
-  const url = `https://api.github.com/repos/${repo}/contents/${path}?ref=${branch}`;
-  const headers = {
-    'Accept': 'application/vnd.github.raw+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-  };
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
+// Helper: get an authenticated GitHub API handle for the current user
+function getGitHubApi() {
+  return api.asUser().withProvider('github', 'github-api');
+}
+
+// Custom error class for 401s — lets getDomain distinguish auth failures
+// from other errors and re-throw outside the try/catch for Forge to intercept.
+class GitHubAuthError extends Error {
+  constructor(path) {
+    super(`GitHub auth expired for ${path}`);
+    this.name = 'GitHubAuthError';
   }
-  const response = await fetch(url, { headers });
+}
+
+// Helper: fetch a file from GitHub via the Forge-authenticated provider
+async function fetchGitHubFile(github, repo, branch, path) {
+  const apiPath = `/repos/${repo}/contents/${path}?ref=${branch}`;
+  const response = await github.fetch(apiPath, {
+    headers: {
+      'Accept': 'application/vnd.github.raw+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (response.status === 401) {
+    throw new GitHubAuthError(path);
+  }
   if (!response.ok) {
     throw new Error(`GitHub fetch failed: ${response.status} for ${path}`);
   }
@@ -99,17 +113,65 @@ function parseLogicalModelYaml(yamlText) {
   return model;
 }
 
-resolver.define('getDomain', async (req) => {
+// Check if the current user has connected their GitHub account
+resolver.define('getAuthStatus', async () => {
   try {
+    const github = getGitHubApi();
+    const hasCredentials = await github.hasCredentials();
+    if (!hasCredentials) {
+      return { authenticated: false };
+    }
+    const account = await github.getAccount();
+    return {
+      authenticated: true,
+      user: account ? { displayName: account.displayName, avatarUrl: account.avatarUrl } : null,
+    };
+  } catch {
+    return { authenticated: false };
+  }
+});
+
+resolver.define('getDomain', async (req) => {
+  // Credential check MUST be outside try/catch — requestCredentials() throws
+  // a platform exception that Forge intercepts to show its OAuth consent UI.
+  // If caught, Forge never sees the throw and can't show the auth prompt.
+  const github = getGitHubApi();
+  if (!(await github.hasCredentials())) {
+    await github.requestCredentials();
+  }
+
+  let result;
+  let needsReauth = false;
+  try {
+    result = await _getDomainInner(github, req);
+  } catch (err) {
+    if (err instanceof GitHubAuthError) {
+      needsReauth = true;
+    } else {
+      return { error: err.message || 'Failed to load domain from GitHub' };
+    }
+  }
+
+  // Token was revoked/expired on GitHub's side — force re-auth.
+  // requestCredentials() MUST be outside try/catch so Forge intercepts
+  // the platform exception and shows the OAuth consent UI.
+  if (needsReauth) {
+    await github.requestCredentials();
+  }
+
+  return result;
+});
+
+async function _getDomainInner(github, req) {
     const payload = req.payload || {};
-    const { repo, branch, domainPath, githubToken } = payload;
+    const { repo, branch, domainPath } = payload;
 
     if (!repo || !domainPath) {
       return { error: `Missing required config: repo=${repo}, domainPath=${domainPath}` };
     }
 
     // 1. Fetch domain JSON
-    const domainText = await fetchGitHubFile(repo, branch || 'main', domainPath, githubToken);
+    const domainText = await fetchGitHubFile(github, repo, branch || 'main', domainPath);
     const domainJson = JSON.parse(domainText);
 
     // 2. Determine base directory for logical-models
@@ -125,7 +187,7 @@ resolver.define('getDomain', async (req) => {
       for (const modelName of modelEntries) {
         try {
           const modelPath = `${baseDir}/logical-models/${modelName}.yml`;
-          const yamlText = await fetchGitHubFile(repo, branch || 'main', modelPath, githubToken);
+          const yamlText = await fetchGitHubFile(github, repo, branch || 'main', modelPath);
           const model = parseLogicalModelYaml(yamlText);
           resolvedModels.push({
             name: model.name || modelName,
@@ -203,20 +265,25 @@ resolver.define('getDomain', async (req) => {
       readOnly: true,
       positionDraggable: false,
     };
-  } catch (err) {
-    return { error: err.message || 'Failed to load domain from GitHub' };
-  }
-});
+}
 
 resolver.define('saveConfig', async ({ payload, context }) => {
   const localId = context.extension?.macro?.id || context.localId || 'default';
-  await storage.set(`config-${localId}`, payload);
+  // Strip githubToken from legacy configs — auth is now handled via OAuth
+  const { githubToken, ...cleanPayload } = payload;
+  await storage.set(`config-${localId}`, cleanPayload);
   return { success: true };
 });
 
 resolver.define('getConfig', async ({ context }) => {
   const localId = context.extension?.macro?.id || context.localId || 'default';
-  return await storage.get(`config-${localId}`);
+  const config = await storage.get(`config-${localId}`);
+  // Strip any legacy githubToken from stored config
+  if (config && config.githubToken) {
+    const { githubToken, ...clean } = config;
+    return clean;
+  }
+  return config;
 });
 
 export const handler = resolver.getDefinitions();

--- a/forge-app/src/resolvers/index.js
+++ b/forge-app/src/resolvers/index.js
@@ -30,6 +30,16 @@ async function fetchGitHubFile(github, repo, branch, path) {
   if (response.status === 401) {
     throw new GitHubAuthError(path);
   }
+  if (response.status === 403) {
+    throw new Error(
+      `Access denied (403) for ${path}. Check that the GitHub OAuth scope includes access to this repository.`
+    );
+  }
+  if (response.status === 404) {
+    throw new Error(
+      `File not found (404): ${path}. Check the repository, branch, and file path are correct.`
+    );
+  }
   if (!response.ok) {
     throw new Error(`GitHub fetch failed: ${response.status} for ${path}`);
   }
@@ -157,70 +167,46 @@ resolver.define('getDomain', async (req) => {
   // the platform exception and shows the OAuth consent UI.
   if (needsReauth) {
     await github.requestCredentials();
+    // Retry with fresh credentials — the original attempt returned nothing
+    try {
+      result = await _getDomainInner(github, req);
+    } catch (retryErr) {
+      return { error: retryErr.message || 'Failed to load domain after re-authentication' };
+    }
   }
 
   return result;
 });
 
 async function _getDomainInner(github, req) {
-    const payload = req.payload || {};
-    const { repo, branch, domainPath } = payload;
+  const payload = req.payload || {};
+  const { repo, branch, domainPath } = payload;
 
-    if (!repo || !domainPath) {
-      return { error: `Missing required config: repo=${repo}, domainPath=${domainPath}` };
-    }
+  if (!repo || !domainPath) {
+    return { error: `Missing required config: repo=${repo}, domainPath=${domainPath}` };
+  }
 
-    // 1. Fetch domain JSON
-    const domainText = await fetchGitHubFile(github, repo, branch || 'main', domainPath);
-    const domainJson = JSON.parse(domainText);
+  // 1. Fetch domain JSON
+  const domainText = await fetchGitHubFile(github, repo, branch || 'main', domainPath);
+  const domainJson = JSON.parse(domainText);
 
-    // 2. Determine base directory for logical-models
-    const pathParts = domainPath.split('/');
-    const baseDir = pathParts.slice(0, -2).join('/'); // Remove layer/filename
+  // 2. Determine base directory for logical-models
+  const pathParts = domainPath.split('/');
+  const baseDir = pathParts.slice(0, -2).join('/'); // Remove layer/filename
 
-    // 3. Check if models are string references (v5) or inline objects (v4)
-    const modelEntries = domainJson.logical?.models ?? [];
-    const resolvedModels = [];
+  // 3. Check if models are string references (v5) or inline objects (v4)
+  const modelEntries = domainJson.logical?.models ?? [];
+  const resolvedModels = [];
 
-    if (modelEntries.length > 0 && typeof modelEntries[0] === 'string') {
-      // v5 format: models are string references to YAML files
-      for (const modelName of modelEntries) {
-        try {
-          const modelPath = `${baseDir}/logical-models/${modelName}.yml`;
-          const yamlText = await fetchGitHubFile(github, repo, branch || 'main', modelPath);
-          const model = parseLogicalModelYaml(yamlText);
-          resolvedModels.push({
-            name: model.name || modelName,
-            schema: model.schema || '',
-            description: model.description || '',
-            columns: (model.columns || []).map(col => ({
-              name: col.name,
-              dataType: col.dataType || 'VARCHAR',
-              description: col.description || '',
-              isPrimaryKey: col.isPrimaryKey || false,
-              isForeignKey: col.isForeignKey || false,
-              isNaturalKey: col.isNaturalKey || false,
-              ...(col.scdType != null ? { scdType: col.scdType } : {}),
-              ...(col.additiveType ? { additiveType: col.additiveType } : {}),
-            })),
-            ...(model.rationale ? { rationale: model.rationale } : {}),
-            ...(model.grain ? { grain: model.grain } : {}),
-            ...(model.modelRole ? { modelRole: model.modelRole } : {}),
-          });
-        } catch (err) {
-          resolvedModels.push({
-            name: modelName,
-            schema: '',
-            description: `Could not load ${modelName}.yml`,
-            columns: [],
-          });
-        }
-      }
-    } else {
-      // v4 format: models are inline objects
-      for (const model of modelEntries) {
+  if (modelEntries.length > 0 && typeof modelEntries[0] === 'string') {
+    // v5 format: models are string references to YAML files
+    for (const modelName of modelEntries) {
+      try {
+        const modelPath = `${baseDir}/logical-models/${modelName}.yml`;
+        const yamlText = await fetchGitHubFile(github, repo, branch || 'main', modelPath);
+        const model = parseLogicalModelYaml(yamlText);
         resolvedModels.push({
-          name: model.name,
+          name: model.name || modelName,
           schema: model.schema || '',
           description: model.description || '',
           columns: (model.columns || []).map(col => ({
@@ -237,34 +223,64 @@ async function _getDomainInner(github, req) {
           ...(model.grain ? { grain: model.grain } : {}),
           ...(model.modelRole ? { modelRole: model.modelRole } : {}),
         });
+      } catch (err) {
+        resolvedModels.push({
+          name: modelName,
+          schema: '',
+          description: `Could not load ${modelName}.yml`,
+          columns: [],
+        });
       }
     }
+  } else {
+    // v4 format: models are inline objects
+    for (const model of modelEntries) {
+      resolvedModels.push({
+        name: model.name,
+        schema: model.schema || '',
+        description: model.description || '',
+        columns: (model.columns || []).map(col => ({
+          name: col.name,
+          dataType: col.dataType || 'VARCHAR',
+          description: col.description || '',
+          isPrimaryKey: col.isPrimaryKey || false,
+          isForeignKey: col.isForeignKey || false,
+          isNaturalKey: col.isNaturalKey || false,
+          ...(col.scdType != null ? { scdType: col.scdType } : {}),
+          ...(col.additiveType ? { additiveType: col.additiveType } : {}),
+        })),
+        ...(model.rationale ? { rationale: model.rationale } : {}),
+        ...(model.grain ? { grain: model.grain } : {}),
+        ...(model.modelRole ? { modelRole: model.modelRole } : {}),
+      });
+    }
+  }
 
-    // 4. Build relationships
-    const relationships = (domainJson.logical?.relationships ?? []).map(rel => ({
-      fromModel: rel.fromModel,
-      fromColumn: rel.fromColumn,
-      toModel: rel.toModel,
-      toColumn: rel.toColumn,
-      cardinality: rel.cardinality || 'many-to-one',
-    }));
+  // 4. Build relationships
+  const relationships = (domainJson.logical?.relationships ?? []).map(rel => ({
+    fromModel: rel.fromModel,
+    fromColumn: rel.fromColumn,
+    toModel: rel.toModel,
+    toColumn: rel.toColumn,
+    cardinality: rel.cardinality || 'many-to-one',
+  }));
 
-    // 5. Build layer from path
-    const layer = pathParts[pathParts.length - 2] || 'silver';
+  // 5. Build layer from path
+  const layer = pathParts[pathParts.length - 2] || 'silver';
 
-    // 6. Assemble DisplayDomain
-    return {
-      schemaVersion: domainJson.schemaVersion || 5,
-      domain: domainJson.domain || pathParts[pathParts.length - 1].replace('.json', ''),
-      layer,
-      stage: 'logical',
-      description: domainJson.description || '',
-      models: resolvedModels,
-      relationships,
-      viewConfig: domainJson.viewConfig || {},
-      readOnly: true,
-      positionDraggable: false,
-    };
+  // 6. Assemble DisplayDomain
+  return {
+    schemaVersion: domainJson.schemaVersion || 5,
+    domain: domainJson.domain || pathParts[pathParts.length - 1].replace('.json', ''),
+    layer,
+    stage: 'logical',
+    description: domainJson.description || '',
+    models: resolvedModels,
+    relationships,
+    viewConfig: domainJson.viewConfig || {},
+    readOnly: true,
+    positionDraggable: false,
+  };
 }
 
 resolver.define('saveConfig', async ({ payload, context }) => {

--- a/forge-app/static/config/src/ConfigPanel.tsx
+++ b/forge-app/static/config/src/ConfigPanel.tsx
@@ -5,16 +5,19 @@ interface MacroConfig {
   repo: string;
   branch: string;
   domainPath: string;
-  githubToken: string;
   height: string;
   githubUrl: string;
+}
+
+interface AuthStatus {
+  authenticated: boolean;
+  user?: { displayName: string; avatarUrl: string } | null;
 }
 
 const DEFAULT_CONFIG: MacroConfig = {
   repo: '',
   branch: 'main',
   domainPath: '',
-  githubToken: '',
   height: '1200',
   githubUrl: '',
 };
@@ -33,12 +36,10 @@ const HEIGHT_OPTIONS = [
  */
 function parseGitHubUrl(url: string): { repo: string; branch: string; domainPath: string } | null {
   const trimmed = url.trim();
-  // Match: github.com/owner/repo/blob/branch/path...
   const match = trimmed.match(/github\.com\/([^/]+\/[^/]+)\/blob\/([^/]+)\/(.+)/);
   if (match) {
     return { repo: match[1], branch: match[2], domainPath: match[3] };
   }
-  // Match: github.com/owner/repo/tree/branch/path... (directory link)
   const treeMatch = trimmed.match(/github\.com\/([^/]+\/[^/]+)\/tree\/([^/]+)\/(.+)/);
   if (treeMatch) {
     return { repo: treeMatch[1], branch: treeMatch[2], domainPath: treeMatch[3] };
@@ -51,6 +52,23 @@ export default function ConfigPanel() {
   const [status, setStatus] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
   const [parsed, setParsed] = useState<{ repo: string; branch: string; domainPath: string } | null>(null);
+  const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+
+  // Check GitHub auth status on mount (display only — no auth trigger)
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const result = await invoke<AuthStatus>('getAuthStatus');
+        setAuthStatus(result);
+      } catch {
+        setAuthStatus({ authenticated: false });
+      } finally {
+        setAuthLoading(false);
+      }
+    }
+    checkAuth();
+  }, []);
 
   // Load existing config
   useEffect(() => {
@@ -58,8 +76,9 @@ export default function ConfigPanel() {
       const context = await view.getContext();
       const macroConfig = (context as any)?.extension?.config;
       if (macroConfig && macroConfig.repo) {
-        setConfig({ ...DEFAULT_CONFIG, ...macroConfig });
-        setParsed({ repo: macroConfig.repo, branch: macroConfig.branch || 'main', domainPath: macroConfig.domainPath });
+        const { githubToken, ...clean } = macroConfig as any;
+        setConfig({ ...DEFAULT_CONFIG, ...clean });
+        setParsed({ repo: clean.repo, branch: clean.branch || 'main', domainPath: clean.domainPath });
         return;
       }
       const saved = await invoke<MacroConfig | null>('getConfig');
@@ -91,6 +110,8 @@ export default function ConfigPanel() {
     setTesting(true);
     setStatus(null);
     try {
+      // getDomain will trigger Forge's OAuth consent UI if not authenticated.
+      // After auth, Forge re-invokes the resolver automatically.
       const result = await invoke<any>('getDomain', config);
       if (result.error) {
         setStatus(`Error: ${result.error}`);
@@ -98,6 +119,9 @@ export default function ConfigPanel() {
         const modelCount = result.models?.length ?? 0;
         const relCount = result.relationships?.length ?? 0;
         setStatus(`Connected! Found ${modelCount} models and ${relCount} relationships.`);
+        // Re-check auth status after successful connection
+        const auth = await invoke<AuthStatus>('getAuthStatus');
+        setAuthStatus(auth);
       }
     } catch (err: any) {
       setStatus(`Error: ${err.message}`);
@@ -117,14 +141,11 @@ export default function ConfigPanel() {
       setStatus(`Save failed: ${err.message}`);
       return;
     }
-    // Close the config panel — try every method available
     try { await view.submit(config); return; } catch {}
     try { await (view as any).close(); return; } catch {}
-    // Last resort: replace the panel content with a done message
     setStatus('__DONE__');
   };
 
-  // If save completed but panel couldn't close, show a minimal "done" state
   if (status === '__DONE__') {
     return (
       <div style={styles.container}>
@@ -138,13 +159,46 @@ export default function ConfigPanel() {
   }
 
   const isSuccess = status?.startsWith('Connected') || status?.startsWith('Saved');
+  const isAuthenticated = authStatus?.authenticated === true;
 
   return (
     <div style={styles.container}>
       <h3 style={styles.title}>ERD Studio Configuration</h3>
       <p style={styles.subtitle}>
-        Paste a GitHub link to your domain JSON file.
+        Paste a GitHub link to your domain JSON file. GitHub authentication is handled
+        automatically via OAuth when you test the connection.
       </p>
+
+      {/* GitHub Auth Status (display only) */}
+      <div style={{ ...styles.field, borderBottom: '1px solid #dfe1e6', paddingBottom: '12px', marginBottom: '16px' }}>
+        <label style={styles.label}>GitHub Account</label>
+        {authLoading ? (
+          <div style={styles.authBox}>
+            <span style={{ fontSize: '13px', color: '#6b778c' }}>Checking...</span>
+          </div>
+        ) : isAuthenticated ? (
+          <div style={{ ...styles.authBox, backgroundColor: '#e3fcef', borderColor: '#006644' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              {authStatus?.user?.avatarUrl && (
+                <img
+                  src={authStatus.user.avatarUrl}
+                  alt=""
+                  style={{ width: '20px', height: '20px', borderRadius: '50%' }}
+                />
+              )}
+              <span style={{ fontSize: '13px', color: '#006644', fontWeight: 600 }}>
+                Connected{authStatus?.user?.displayName ? ` as ${authStatus.user.displayName}` : ''}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div style={styles.authBox}>
+            <span style={{ fontSize: '13px', color: '#6b778c' }}>
+              Not connected — click Test Connection to authenticate via OAuth.
+            </span>
+          </div>
+        )}
+      </div>
 
       <div style={styles.field}>
         <label style={styles.label}>GitHub URL</label>
@@ -168,21 +222,6 @@ export default function ConfigPanel() {
             Could not parse URL. Expected format: github.com/owner/repo/blob/branch/path/to/file.json
           </span>
         )}
-      </div>
-
-      <div style={styles.field}>
-        <label style={styles.label}>GitHub Token (optional)</label>
-        <input
-          style={styles.input}
-          type="password"
-          placeholder="ghp_... or github_pat_..."
-          value={config.githubToken}
-          onChange={(e) => {
-            setConfig((prev) => ({ ...prev, githubToken: e.target.value }));
-            setStatus(null);
-          }}
-        />
-        <span style={styles.hint}>Required for private repos. Needs Contents read permission.</span>
       </div>
 
       <div style={{ ...styles.field, borderTop: '1px solid #dfe1e6', paddingTop: '12px', marginTop: '16px' }}>
@@ -316,5 +355,11 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#ffffff',
     cursor: 'pointer',
     fontWeight: 600,
+  },
+  authBox: {
+    padding: '8px 12px',
+    borderRadius: '3px',
+    border: '1px solid #dfe1e6',
+    backgroundColor: '#f4f5f7',
   },
 };

--- a/forge-app/static/config/src/ConfigPanel.tsx
+++ b/forge-app/static/config/src/ConfigPanel.tsx
@@ -119,14 +119,16 @@ export default function ConfigPanel() {
         const modelCount = result.models?.length ?? 0;
         const relCount = result.relationships?.length ?? 0;
         setStatus(`Connected! Found ${modelCount} models and ${relCount} relationships.`);
-        // Re-check auth status after successful connection
-        const auth = await invoke<AuthStatus>('getAuthStatus');
-        setAuthStatus(auth);
       }
     } catch (err: any) {
       setStatus(`Error: ${err.message}`);
     } finally {
       setTesting(false);
+      // Always re-check auth status — covers success, failure, and cancelled OAuth flows
+      try {
+        const auth = await invoke<AuthStatus>('getAuthStatus');
+        setAuthStatus(auth);
+      } catch {}
     }
   };
 

--- a/forge-app/static/frontend/src/App.tsx
+++ b/forge-app/static/frontend/src/App.tsx
@@ -45,7 +45,6 @@ function parseGitHubUrl(url: string) {
 
 function InlineConfig({ onSaved }: { onSaved: () => void }) {
   const [url, setUrl] = useState('');
-  const [token, setToken] = useState('');
   const [height, setHeight] = useState('1200');
   const [status, setStatus] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -57,7 +56,9 @@ function InlineConfig({ onSaved }: { onSaved: () => void }) {
     setSaving(true);
     setStatus(null);
     try {
-      const result = await invoke<any>('getDomain', { ...parsed, githubToken: token, height });
+      // getDomain triggers Forge's OAuth consent UI if not authenticated.
+      // After auth, Forge re-invokes the resolver automatically.
+      const result = await invoke<any>('getDomain', { ...parsed, height });
       if (result.error) setStatus(`Error: ${result.error}`);
       else setStatus(`Connected! Found ${result.models?.length ?? 0} models and ${result.relationships?.length ?? 0} relationships.`);
     } catch (err: any) {
@@ -71,7 +72,7 @@ function InlineConfig({ onSaved }: { onSaved: () => void }) {
     if (!parsed) { setStatus('Please paste a valid GitHub URL.'); return; }
     setSaving(true);
     try {
-      await invoke('saveConfig', { ...parsed, githubToken: token, height, githubUrl: url });
+      await invoke('saveConfig', { ...parsed, height, githubUrl: url });
       onSaved();
     } catch (err: any) {
       setStatus(`Save failed: ${err.message}`);
@@ -85,7 +86,8 @@ function InlineConfig({ onSaved }: { onSaved: () => void }) {
     <div style={{ padding: '32px', maxWidth: '560px', margin: '0 auto', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif' }}>
       <h2 style={{ margin: '0 0 4px', fontSize: '18px', color: '#172b4d' }}>ERD Studio</h2>
       <p style={{ margin: '0 0 20px', fontSize: '13px', color: '#6b778c' }}>
-        Paste a GitHub link to your domain JSON file to render an interactive ERD diagram.
+        Paste a GitHub link to your domain JSON file. GitHub authentication is handled
+        automatically via OAuth when you test the connection.
       </p>
 
       <label style={labelStyle}>GitHub URL</label>
@@ -108,17 +110,6 @@ function InlineConfig({ onSaved }: { onSaved: () => void }) {
           Could not parse URL. Expected: github.com/owner/repo/blob/branch/path/to/file.json
         </div>
       )}
-
-      <div style={{ marginTop: '16px' }}>
-        <label style={labelStyle}>GitHub Token <span style={{ fontWeight: 400, color: '#97a0af' }}>(required for private repos)</span></label>
-        <input
-          style={inputStyle}
-          type="password"
-          placeholder="ghp_... or github_pat_..."
-          value={token}
-          onChange={(e) => { setToken(e.target.value); setStatus(null); }}
-        />
-      </div>
 
       <div style={{ marginTop: '16px' }}>
         <label style={labelStyle}>Diagram Height</label>
@@ -205,6 +196,8 @@ function ERDViewer() {
       const h = parseInt(config.height, 10);
       if (h && h > 0) setHeightPx(h);
 
+      // getDomain triggers Forge's OAuth consent UI if not authenticated.
+      // After auth, Forge re-invokes the resolver automatically.
       const result = await invoke<any>('getDomain', config);
       if (result.error) {
         setError(result.error);
@@ -241,7 +234,6 @@ function ERDViewer() {
     const h = parseInt(newHeight, 10);
     if (!h || h <= 0) return;
     setHeightPx(h);
-    // Persist to KVS
     try {
       const config = await invoke<any>('getConfig');
       if (config) {
@@ -333,7 +325,8 @@ function ERDViewer() {
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
-            defaultViewport={{ x: 50, y: 50, zoom: 1 }}
+            fitView
+            fitViewOptions={{ padding: 0.15, maxZoom: 1.5 }}
             nodesDraggable={false}
             nodesConnectable={false}
             elementsSelectable={true}


### PR DESCRIPTION
## Summary

- **Replaces manual GitHub PAT input** with Forge's built-in External Authentication (OAuth 2.0) flow — users authenticate via a standard GitHub OAuth popup and the app never sees or stores raw tokens
- **Registers a GitHub OAuth App** with Forge's fixed callback URL (`id.atlassian.com/outboundAuth/finish`) and configures the full provider in `manifest.yml` (authorization, token exchange, profile retrieval)
- **Handles revoked/expired tokens** by detecting 401 responses from GitHub and re-triggering the OAuth consent flow via Forge's platform UI
- **Auto-fits diagram viewport** using React Flow's `fitView` so all models are visible on load

## Changes

| File | Change |
|------|--------|
| `manifest.yml` | Added `providers.auth` (GitHub OAuth), `remotes`, updated egress permissions |
| `src/resolvers/index.js` | Refactored to `api.asUser().withProvider()`, added `getAuthStatus` resolver, 401 re-auth handling, migrated to `@forge/kvs` |
| `ConfigPanel.tsx` | Removed PAT input, added OAuth status display |
| `App.tsx` | Removed PAT from inline config, added `fitView` for auto-fit |
| `package.json` | Added `@forge/kvs`, `tslib` dependencies |

## Security improvements

- App **never handles raw tokens** — Forge manages the entire OAuth lifecycle per user
- Tokens stored in Forge's platform infrastructure, not app-managed KVS
- Legacy PATs stripped from stored configs on read/write
- Credential revocation handled gracefully (401 → re-auth prompt)

## Test plan

- [ ] Insert ERD Studio macro on a Confluence page
- [ ] Verify "Configure access" prompt appears for unauthenticated users
- [ ] Complete GitHub OAuth flow and verify diagram loads
- [ ] Revoke GitHub access and verify re-auth prompt appears on next load
- [ ] Verify `fitView` shows all models within the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)