### PR TITLE
feat: sync modal UX overhaul and data type normalisation

### DIFF
--- a/src/services/discrepancyService.ts
+++ b/src/services/discrepancyService.ts
@@ -26,6 +26,66 @@ function relationshipKey(r: { fromModel: string; fromColumn: string; toModel: st
 }
 
 /**
+ * Alias map: common synonyms → canonical type name.
+ * Applied after lowercasing and whitespace normalisation.
+ */
+const TYPE_ALIASES: Record<string, string> = {
+  // String family
+  varchar:  'string',
+  text:     'string',
+  char:     'string',
+  nvarchar: 'string',
+  nchar:    'string',
+  // Integer family
+  integer:  'int',
+  tinyint:  'int',
+  // Numeric / decimal family
+  numeric:  'decimal',
+  number:   'decimal',
+  // Float family
+  float:    'double',
+  real:     'double',
+  float64:  'double',
+  // Boolean family
+  bool:     'boolean',
+  // Timestamp family
+  timestamp_ntz: 'timestamp',
+  timestamp_ltz: 'timestamp',
+  datetime:      'timestamp',
+  datetime2:     'timestamp',
+};
+
+/**
+ * Normalise a data type string for comparison purposes.
+ *
+ * Steps:
+ * 1. Lowercase
+ * 2. Trim outer whitespace
+ * 3. Normalise whitespace inside parentheses: `decimal(15, 5)` → `decimal(15,5)`
+ * 4. Map common aliases to a canonical name (varchar → string, integer → int, …)
+ *
+ * The original (un-normalised) strings are still stored on the discrepancy
+ * result so the UI shows what the user actually typed / what dbt reports.
+ */
+export function normaliseDataType(raw: string | undefined): string {
+  if (!raw) return '';
+  let t = raw.trim().toLowerCase();
+  // Strip spaces inside parens: `decimal( 15 , 5 )` → `decimal(15,5)`
+  t = t.replace(/\(\s*/g, '(').replace(/\s*\)/g, ')').replace(/\s*,\s*/g, ',');
+  // Extract base name (everything before the first '(')
+  const parenIdx = t.indexOf('(');
+  const baseName = parenIdx >= 0 ? t.slice(0, parenIdx) : t;
+  const suffix = parenIdx >= 0 ? t.slice(parenIdx) : '';
+  const canonical = TYPE_ALIASES[baseName] ?? baseName;
+  return canonical + suffix;
+}
+
+/** Compare two data type strings using normalised forms. */
+function dataTypesMatch(a: string | undefined, b: string | undefined): boolean {
+  return normaliseDataType(a) === normaliseDataType(b);
+}
+
+/**
  * Compare columns between two matched models.
  *
  * @param stubColumns - When true, columns that exist in the target but not the
@@ -48,7 +108,7 @@ function compareColumns(
 
     if (!targetCol) {
       result.push({ name: col.name, status: 'extra', sourceDataType: col.dataType });
-    } else if (col.dataType !== targetCol.dataType) {
+    } else if (!dataTypesMatch(col.dataType, targetCol.dataType)) {
       result.push({
         name: col.name,
         status: 'type-mismatch',

--- a/src/services/discrepancyService.ts
+++ b/src/services/discrepancyService.ts
@@ -36,9 +36,14 @@ const TYPE_ALIASES: Record<string, string> = {
   char:     'string',
   nvarchar: 'string',
   nchar:    'string',
+  ntext:    'string',
   // Integer family
   integer:  'int',
   tinyint:  'int',
+  smallint: 'int',
+  int64:    'int',
+  // Big integer family
+  bigint:   'bigint',
   // Numeric / decimal family
   numeric:  'decimal',
   number:   'decimal',
@@ -53,6 +58,12 @@ const TYPE_ALIASES: Record<string, string> = {
   timestamp_ltz: 'timestamp',
   datetime:      'timestamp',
   datetime2:     'timestamp',
+  // Binary family
+  bytea:    'binary',
+  blob:     'binary',
+  varbinary: 'binary',
+  // JSON family
+  jsonb:    'json',
 };
 
 /**

--- a/test/unit/discrepancyService.test.ts
+++ b/test/unit/discrepancyService.test.ts
@@ -409,6 +409,13 @@ describe('normaliseDataType', () => {
     expect(normaliseDataType('timestamp_ltz')).toBe('timestamp');
     expect(normaliseDataType('datetime')).toBe('timestamp');
     expect(normaliseDataType('datetime2')).toBe('timestamp');
+    expect(normaliseDataType('ntext')).toBe('string');
+    expect(normaliseDataType('smallint')).toBe('int');
+    expect(normaliseDataType('int64')).toBe('int');
+    expect(normaliseDataType('bytea')).toBe('binary');
+    expect(normaliseDataType('blob')).toBe('binary');
+    expect(normaliseDataType('varbinary')).toBe('binary');
+    expect(normaliseDataType('jsonb')).toBe('json');
   });
 
   it('normalises whitespace inside parentheses', () => {
@@ -428,7 +435,7 @@ describe('normaliseDataType', () => {
     expect(normaliseDataType('timestamp')).toBe('timestamp');
     expect(normaliseDataType('double')).toBe('double');
     expect(normaliseDataType('boolean')).toBe('boolean');
-    expect(normaliseDataType('smallint')).toBe('smallint');
+    expect(normaliseDataType('smallint')).toBe('int');
   });
 
   it('handles undefined and empty string', () => {

--- a/test/unit/discrepancyService.test.ts
+++ b/test/unit/discrepancyService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { compare } from '../../src/services/discrepancyService';
+import { compare, normaliseDataType } from '../../src/services/discrepancyService';
 import type { DisplayDomain, DisplayModel, DisplayRelationship } from '../../src/types/display';
 
 // ---------------------------------------------------------------------------
@@ -126,21 +126,69 @@ describe('DiscrepancyService.compare', () => {
       expect(report.summary.missingColumns).toBe(1);
     });
 
-    it('reports data type mismatches', () => {
+    it('reports data type mismatches for genuinely different types', () => {
       const source = makeDomain({
-        models: [makeModel('dim_customer', [makeColumn('email_hash', 'VARCHAR')])],
+        models: [makeModel('dim_customer', [makeColumn('email_hash', 'string')])],
       });
       const target = makeDomain({
-        models: [makeModel('dim_customer', [makeColumn('email_hash', 'TEXT')])],
+        models: [makeModel('dim_customer', [makeColumn('email_hash', 'int')])],
       });
 
       const report = compare(source, target);
       const model = report.models.find((m) => m.name === 'dim_customer')!;
       const mismatch = model.columns.find((c) => c.name === 'email_hash');
       expect(mismatch?.status).toBe('type-mismatch');
-      expect(mismatch?.sourceDataType).toBe('VARCHAR');
-      expect(mismatch?.targetDataType).toBe('TEXT');
+      expect(mismatch?.sourceDataType).toBe('string');
+      expect(mismatch?.targetDataType).toBe('int');
       expect(report.summary.dataTypeMismatches).toBe(1);
+    });
+
+    it('treats VARCHAR and TEXT as equivalent to string (no type-mismatch)', () => {
+      const source = makeDomain({
+        models: [makeModel('dim_customer', [
+          makeColumn('a', 'VARCHAR'),
+          makeColumn('b', 'TEXT'),
+          makeColumn('c', 'String'),
+        ])],
+      });
+      const target = makeDomain({
+        models: [makeModel('dim_customer', [
+          makeColumn('a', 'string'),
+          makeColumn('b', 'string'),
+          makeColumn('c', 'string'),
+        ])],
+      });
+
+      const report = compare(source, target);
+      const model = report.models.find((m) => m.name === 'dim_customer')!;
+      expect(model.columns.every((c) => c.status === 'matched')).toBe(true);
+      expect(report.summary.dataTypeMismatches).toBe(0);
+    });
+
+    it('treats integer and INT as equivalent (case-insensitive)', () => {
+      const source = makeDomain({
+        models: [makeModel('dim_customer', [makeColumn('id', 'INTEGER')])],
+      });
+      const target = makeDomain({
+        models: [makeModel('dim_customer', [makeColumn('id', 'int')])],
+      });
+
+      const report = compare(source, target);
+      const model = report.models.find((m) => m.name === 'dim_customer')!;
+      expect(model.columns[0].status).toBe('matched');
+    });
+
+    it('normalises decimal spacing: decimal(15, 5) matches decimal(15,5)', () => {
+      const source = makeDomain({
+        models: [makeModel('dim_customer', [makeColumn('amount', 'decimal(15, 5)')])],
+      });
+      const target = makeDomain({
+        models: [makeModel('dim_customer', [makeColumn('amount', 'decimal(15,5)')])],
+      });
+
+      const report = compare(source, target);
+      const model = report.models.find((m) => m.name === 'dim_customer')!;
+      expect(model.columns[0].status).toBe('matched');
     });
 
     it('populates columns as missing for missing models', () => {
@@ -327,5 +375,70 @@ describe('DiscrepancyService.compare', () => {
       expect(report.summary.totalModels).toBe(0);
       expect(report.summary.totalColumns).toBe(0);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normaliseDataType unit tests
+// ---------------------------------------------------------------------------
+
+describe('normaliseDataType', () => {
+  it('lowercases everything', () => {
+    expect(normaliseDataType('STRING')).toBe('string');
+    expect(normaliseDataType('Int')).toBe('int');
+    expect(normaliseDataType('BIGINT')).toBe('bigint');
+  });
+
+  it('maps common aliases to canonical names', () => {
+    expect(normaliseDataType('varchar')).toBe('string');
+    expect(normaliseDataType('VARCHAR')).toBe('string');
+    expect(normaliseDataType('text')).toBe('string');
+    expect(normaliseDataType('TEXT')).toBe('string');
+    expect(normaliseDataType('nvarchar')).toBe('string');
+    expect(normaliseDataType('char')).toBe('string');
+    expect(normaliseDataType('integer')).toBe('int');
+    expect(normaliseDataType('INTEGER')).toBe('int');
+    expect(normaliseDataType('tinyint')).toBe('int');
+    expect(normaliseDataType('numeric')).toBe('decimal');
+    expect(normaliseDataType('number')).toBe('decimal');
+    expect(normaliseDataType('float')).toBe('double');
+    expect(normaliseDataType('real')).toBe('double');
+    expect(normaliseDataType('float64')).toBe('double');
+    expect(normaliseDataType('bool')).toBe('boolean');
+    expect(normaliseDataType('timestamp_ntz')).toBe('timestamp');
+    expect(normaliseDataType('timestamp_ltz')).toBe('timestamp');
+    expect(normaliseDataType('datetime')).toBe('timestamp');
+    expect(normaliseDataType('datetime2')).toBe('timestamp');
+  });
+
+  it('normalises whitespace inside parentheses', () => {
+    expect(normaliseDataType('decimal(15, 5)')).toBe('decimal(15,5)');
+    expect(normaliseDataType('decimal( 15 , 5 )')).toBe('decimal(15,5)');
+    expect(normaliseDataType('DECIMAL(28, 10)')).toBe('decimal(28,10)');
+  });
+
+  it('applies aliases with precision parameters', () => {
+    expect(normaliseDataType('numeric(18,2)')).toBe('decimal(18,2)');
+    expect(normaliseDataType('NUMBER(10, 0)')).toBe('decimal(10,0)');
+  });
+
+  it('preserves types without aliases', () => {
+    expect(normaliseDataType('bigint')).toBe('bigint');
+    expect(normaliseDataType('date')).toBe('date');
+    expect(normaliseDataType('timestamp')).toBe('timestamp');
+    expect(normaliseDataType('double')).toBe('double');
+    expect(normaliseDataType('boolean')).toBe('boolean');
+    expect(normaliseDataType('smallint')).toBe('smallint');
+  });
+
+  it('handles undefined and empty string', () => {
+    expect(normaliseDataType(undefined)).toBe('');
+    expect(normaliseDataType('')).toBe('');
+    expect(normaliseDataType('  ')).toBe('');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(normaliseDataType('  string  ')).toBe('string');
+    expect(normaliseDataType(' VARCHAR ')).toBe('string');
   });
 });

--- a/webview/components/DiscrepancyPanel/DiscrepancyPanel.css
+++ b/webview/components/DiscrepancyPanel/DiscrepancyPanel.css
@@ -459,15 +459,15 @@
 
 .disc-panel__sync-footer-btn {
   width: 100%;
-  padding: 6px 12px;
+  padding: 8px 16px;
   border: none;
   border-radius: 4px;
   background: var(--button-bg);
   color: var(--button-fg);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.1s ease;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
 }
 
 .disc-panel__sync-footer-btn:hover:not(:disabled) {
@@ -480,9 +480,10 @@
 }
 
 .disc-panel__sync-footer-hint {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--editor-fg);
-  opacity: 0.4;
+  opacity: 0.5;
+  text-align: center;
 }
 
 /* ---------------------------------------------------------------------------

--- a/webview/components/DiscrepancyPanel/DiscrepancyPanel.css
+++ b/webview/components/DiscrepancyPanel/DiscrepancyPanel.css
@@ -446,7 +446,7 @@
   border: none;
   border-radius: 4px;
   background: var(--stage-physical);
-  color: #000;
+  color: var(--button-fg, #fff);
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;

--- a/webview/components/DiscrepancyPanel/SyncControls.tsx
+++ b/webview/components/DiscrepancyPanel/SyncControls.tsx
@@ -4,7 +4,7 @@
  * Three sub-components:
  *   SyncRadio    — inline radio pair (Logical | Physical) for a single discrepancy item
  *   SyncBulkBar  — global "All Logical / All Physical" bulk selection bar
- *   SyncFooter   — sticky "Generate Sync Plan" button at the bottom
+ *   SyncFooter   — sticky "Apply Changes" button at the bottom
  */
 
 import React, { useCallback, useMemo } from 'react';
@@ -92,7 +92,7 @@ export const SyncBulkBar: React.FC<SyncBulkBarProps> = ({ allKeys }) => {
 };
 
 // ---------------------------------------------------------------------------
-// SyncFooter — generate sync plan button + status
+// SyncFooter — apply changes button + status
 // ---------------------------------------------------------------------------
 
 interface SyncFooterProps {
@@ -110,6 +110,8 @@ export const SyncFooter: React.FC<SyncFooterProps> = ({ totalKeys }) => {
     [syncSelections],
   );
 
+  const remaining = totalKeys - selectedCount;
+
   const handleGenerate = useCallback(() => {
     if (selectedCount === 0) return;
     vscode.postMessage({ type: 'generateSyncPlan', payload: { selections: syncSelections } });
@@ -125,13 +127,13 @@ export const SyncFooter: React.FC<SyncFooterProps> = ({ totalKeys }) => {
         <div className="disc-panel__sync-footer-status">
           <span className="disc-panel__sync-footer-check">✓</span>
           <span>
-            Sync plan written ({syncPlanGenerated.totalActions} action{syncPlanGenerated.totalActions !== 1 ? 's' : ''})
+            Changes prepared — {syncPlanGenerated.totalActions} action{syncPlanGenerated.totalActions !== 1 ? 's' : ''} ready
           </span>
         </div>
         <button
           className="disc-panel__sync-execute-btn"
           onClick={handleLaunchClaude}
-          title="Launch Claude Code to execute the sync plan"
+          title="Launch Claude Code to execute the changes"
         >
           Execute with Claude
         </button>
@@ -146,11 +148,16 @@ export const SyncFooter: React.FC<SyncFooterProps> = ({ totalKeys }) => {
         disabled={selectedCount === 0}
         onClick={handleGenerate}
       >
-        Generate Sync Plan{selectedCount > 0 ? ` (${selectedCount})` : ''}
+        Apply Changes{selectedCount > 0 ? ` (${selectedCount})` : ''}
       </button>
       {totalKeys > 0 && selectedCount === 0 && (
         <span className="disc-panel__sync-footer-hint">
-          Select ground truth for items above
+          Choose a side for each difference above, then apply
+        </span>
+      )}
+      {selectedCount > 0 && remaining > 0 && (
+        <span className="disc-panel__sync-footer-hint">
+          {remaining} difference{remaining !== 1 ? 's' : ''} still need{remaining === 1 ? 's' : ''} a decision
         </span>
       )}
     </div>

--- a/webview/components/SyncMergeModal/SyncMergeModal.css
+++ b/webview/components/SyncMergeModal/SyncMergeModal.css
@@ -234,7 +234,7 @@
   gap: 10px;
   padding: 10px 20px;
   background: var(--stage-physical-bg);
-  border-bottom: 1px solid rgba(34, 197, 94, 0.2);
+  border-bottom: 1px solid var(--stage-physical-border, rgba(34, 197, 94, 0.2));
   flex-shrink: 0;
   animation: sync-modal__fade-in 0.3s ease;
 }
@@ -339,7 +339,7 @@
    --------------------------------------------------------------------------- */
 
 .sync-modal__row--model-header {
-  background: rgba(128, 128, 128, 0.1);
+  background: var(--stage-ghost-bg, rgba(128, 128, 128, 0.1));
 }
 
 /* Separator above each model header row (except the very first body row) */
@@ -471,14 +471,14 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 
 /* Logical hover preview */
 .sync-modal__accept-btn--logical:hover {
-  background: rgba(96, 165, 250, 0.12);
+  background: var(--stage-logical-hover, rgba(96, 165, 250, 0.12));
   border-color: var(--stage-logical, #60a5fa);
   color: var(--stage-logical, #60a5fa);
 }
 
 /* Physical hover preview */
 .sync-modal__accept-btn--physical:hover {
-  background: rgba(34, 197, 94, 0.12);
+  background: var(--stage-physical-hover, rgba(34, 197, 94, 0.12));
   border-color: var(--stage-physical, #22c55e);
   color: var(--stage-physical, #22c55e);
 }
@@ -489,7 +489,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   background: var(--stage-logical, #60a5fa);
   border-color: var(--stage-logical, #60a5fa);
   color: var(--button-fg, #fff);
-  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.3);
+  box-shadow: 0 0 0 1px var(--stage-logical-ring, rgba(96, 165, 250, 0.3));
 }
 
 /* Physical accept — green when selected */
@@ -498,7 +498,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   background: var(--stage-physical, #22c55e);
   border-color: var(--stage-physical, #22c55e);
   color: var(--button-fg, #fff);
-  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.3);
+  box-shadow: 0 0 0 1px var(--stage-physical-ring, rgba(34, 197, 94, 0.3));
 }
 
 /* ---------------------------------------------------------------------------

--- a/webview/components/SyncMergeModal/SyncMergeModal.css
+++ b/webview/components/SyncMergeModal/SyncMergeModal.css
@@ -1,5 +1,8 @@
 /**
  * SyncMergeModal styles — VS Code-style merge editor overlay.
+ *
+ * Visual hierarchy: Header → Toolbar → Progress → Completion → Table → Footer
+ * Stage colours:  Logical = blue (#60a5fa)  ·  Physical = green (#22c55e)
  */
 
 /* ---------------------------------------------------------------------------
@@ -22,78 +25,83 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: min(920px, 88vw);
+  width: min(960px, 90vw);
   height: min(720px, 82vh);
   z-index: 201;
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
-  border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  border-radius: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
 /* ---------------------------------------------------------------------------
-   Header
+   Header — two-line: title + explanatory subtitle
    --------------------------------------------------------------------------- */
 
 .sync-modal__header {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 20px 12px;
   border-bottom: 1px solid var(--panel-border);
   flex-shrink: 0;
 }
 
-.sync-modal__header-title {
+.sync-modal__header-content {
   flex: 1;
+  min-width: 0;
+}
+
+.sync-modal__header-title-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--editor-fg);
+  gap: 8px;
 }
 
 .sync-modal__header-icon {
-  font-size: 13px;
-  opacity: 0.7;
+  font-size: 16px;
+  opacity: 0.6;
 }
 
 .sync-modal__header-domain {
+  font-size: 14px;
   font-weight: 700;
+  color: var(--editor-fg);
 }
 
-.sync-modal__header-sep {
-  opacity: 0.35;
-}
-
-.sync-modal__header-stage {
-  font-weight: 700;
-}
-
-.sync-modal__header-arrow {
-  opacity: 0.4;
+.sync-modal__header-subtitle {
+  margin: 5px 0 0;
   font-size: 11px;
+  line-height: 1.45;
+  color: var(--editor-fg);
+  opacity: 0.65;
+  font-weight: 400;
+}
+
+.sync-modal__header-subtitle strong {
+  font-weight: 600;
+  opacity: 1;
 }
 
 .sync-modal__close {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border: none;
-  border-radius: 3px;
+  border-radius: 4px;
   background: transparent;
   color: var(--editor-fg);
   font-size: 18px;
   cursor: pointer;
-  opacity: 0.5;
-  transition: opacity 0.1s, background 0.1s;
+  opacity: 0.45;
+  transition: opacity 0.15s, background 0.15s;
   flex-shrink: 0;
+  margin-top: 1px;
 }
 
 .sync-modal__close:hover {
@@ -103,29 +111,39 @@
 }
 
 /* ---------------------------------------------------------------------------
-   Bulk toolbar
+   Toolbar — bulk actions with stage-colored accents
    --------------------------------------------------------------------------- */
 
 .sync-modal__toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 6px;
+  padding: 8px 20px;
   border-bottom: 1px solid var(--panel-border);
   flex-shrink: 0;
 }
 
 .sync-modal__bulk-btn {
-  padding: 3px 10px;
+  padding: 4px 12px;
   border: 1px solid var(--panel-border);
-  border-radius: 3px;
+  border-radius: 4px;
   background: transparent;
   color: var(--editor-fg);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
-  opacity: 0.75;
-  transition: all 0.1s;
+  opacity: 0.8;
+  transition: all 0.15s;
+  white-space: nowrap;
+  border-left: 3px solid transparent;
+}
+
+.sync-modal__bulk-btn--logical {
+  border-left-color: var(--stage-logical, #60a5fa);
+}
+
+.sync-modal__bulk-btn--physical {
+  border-left-color: var(--stage-physical, #22c55e);
 }
 
 .sync-modal__bulk-btn:hover {
@@ -133,31 +151,109 @@
   background: var(--selection-bg);
 }
 
+.sync-modal__bulk-btn--active {
+  opacity: 1;
+  background: var(--button-bg);
+  color: var(--button-fg);
+  border-color: var(--button-bg);
+  border-left-color: var(--button-bg);
+}
+
+.sync-modal__toolbar-sep {
+  width: 1px;
+  height: 18px;
+  background: var(--panel-border);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
 .sync-modal__toolbar-count {
   margin-left: auto;
   font-size: 11px;
+  font-weight: 500;
   color: var(--editor-fg);
-  opacity: 0.5;
+  opacity: 0.65;
 }
 
 /* ---------------------------------------------------------------------------
-   Progress bar
+   Progress section — labeled bar with status text
    --------------------------------------------------------------------------- */
 
-.sync-modal__progress {
-  height: 3px;
-  background: var(--panel-border);
+.sync-modal__progress-section {
+  padding: 10px 20px 12px;
+  border-bottom: 1px solid var(--panel-border);
   flex-shrink: 0;
+}
+
+.sync-modal__progress-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.sync-modal__progress-label-text {
+  font-size: 11px;
+  color: var(--editor-fg);
+  opacity: 0.65;
+  font-weight: 500;
+}
+
+.sync-modal__progress-done-badge {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--stage-physical, #22c55e);
+  letter-spacing: 0.2px;
+}
+
+.sync-modal__progress {
+  height: 6px;
+  background: var(--panel-border);
+  border-radius: 3px;
+  overflow: hidden;
 }
 
 .sync-modal__progress-fill {
   height: 100%;
   background: var(--button-bg);
+  border-radius: 3px;
   transition: width 0.3s ease;
 }
 
 .sync-modal__progress-fill--done {
   background: var(--stage-physical, #22c55e);
+}
+
+/* ---------------------------------------------------------------------------
+   Completion banner — appears when all differences resolved
+   --------------------------------------------------------------------------- */
+
+.sync-modal__completion-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  background: var(--stage-physical-bg);
+  border-bottom: 1px solid rgba(34, 197, 94, 0.2);
+  flex-shrink: 0;
+  animation: sync-modal__fade-in 0.3s ease;
+}
+
+.sync-modal__completion-icon {
+  font-size: 15px;
+  color: var(--stage-physical, #22c55e);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.sync-modal__completion-text {
+  font-size: 12px;
+  color: var(--editor-fg);
+  line-height: 1.4;
+}
+
+.sync-modal__completion-text strong {
+  font-weight: 600;
 }
 
 /* ---------------------------------------------------------------------------
@@ -180,12 +276,12 @@
   table-layout: fixed;
 }
 
-.sync-modal__col--chevron { width: 4%; }
-.sync-modal__col--stage   { width: 27%; }
-.sync-modal__col--item    { width: 42%; }
+.sync-modal__col--chevron { width: 3.5%; }
+.sync-modal__col--stage   { width: 28%; }
+.sync-modal__col--item    { width: 40.5%; }
 
 /* ---------------------------------------------------------------------------
-   Thead — sticky
+   Thead — sticky with stage-colored bottom borders
    --------------------------------------------------------------------------- */
 
 .sync-modal__thead {
@@ -197,7 +293,7 @@
 }
 
 .sync-modal__th {
-  padding: 8px 12px;
+  padding: 10px 14px;
   font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
@@ -214,18 +310,15 @@
 
 .sync-modal__th--item {
   color: var(--editor-fg);
-  opacity: 0.5;
+  opacity: 0.45;
 }
 
-.sync-modal__th-sub {
-  display: block;
-  font-size: 8px;
-  font-weight: 400;
-  text-transform: none;
-  letter-spacing: 0;
-  opacity: 0.55;
-  color: var(--editor-fg);
-  margin-top: 1px;
+.sync-modal__th--logical {
+  border-bottom: 2px solid var(--stage-logical, #60a5fa);
+}
+
+.sync-modal__th--physical {
+  border-bottom: 2px solid var(--stage-physical, #22c55e);
 }
 
 /* ---------------------------------------------------------------------------
@@ -234,6 +327,7 @@
 
 .sync-modal__row {
   border-bottom: 1px solid var(--panel-border);
+  transition: background 0.15s ease;
 }
 
 .sync-modal__row:last-child {
@@ -245,7 +339,7 @@
    --------------------------------------------------------------------------- */
 
 .sync-modal__row--model-header {
-  background: rgba(128, 128, 128, 0.07);
+  background: rgba(128, 128, 128, 0.1);
 }
 
 /* Separator above each model header row (except the very first body row) */
@@ -254,8 +348,8 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 }
 
 .sync-modal__row--model-header .sync-modal__cell {
-  padding-top: 9px;
-  padding-bottom: 9px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 /* When all items in this model are resolved, give the header a green tint */
@@ -288,7 +382,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 .sync-modal__row--mismatch,
 .sync-modal__row--type-mismatch,
 .sync-modal__row--cardinality-mismatch {
-  background: rgba(204, 100, 0, 0.04); /* mismatch tint */
+  background: rgba(239, 68, 68, 0.04);
 }
 
 .sync-modal__row--conflict:hover {
@@ -297,7 +391,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 
 /* Indent the item cell for column rows */
 .sync-modal__row--column .sync-modal__cell--item {
-  padding-left: 20px;
+  padding-left: 22px;
 }
 
 /* ---------------------------------------------------------------------------
@@ -305,7 +399,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
    --------------------------------------------------------------------------- */
 
 .sync-modal__cell {
-  padding: 7px 12px;
+  padding: 8px 14px;
   vertical-align: middle;
   font-size: 12px;
   color: var(--editor-fg);
@@ -314,7 +408,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 /* Chevron column cell — narrow, no horizontal padding, holds the toggle */
 .sync-modal__cell--chevron {
   padding: 0;
-  width: 4%;
+  width: 3.5%;
   text-align: center;
   vertical-align: middle;
   /* border-left applied inline per-row for the accent colour */
@@ -325,9 +419,15 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   background: var(--selection-bg);
 }
 
-/* When the other side is selected */
+/* When the other side is selected — dim and strike through */
 .sync-modal__cell--rejected {
-  opacity: 0.4;
+  opacity: 0.35;
+}
+
+.sync-modal__cell--rejected .sync-modal__cell-value {
+  text-decoration: line-through;
+  text-decoration-color: var(--editor-fg);
+  text-decoration-thickness: 1px;
 }
 
 .sync-modal__cell-value {
@@ -346,28 +446,41 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 }
 
 /* ---------------------------------------------------------------------------
-   Accept buttons — stage-coloured when selected
+   Accept buttons — "Keep Logical" / "Keep Physical"
    --------------------------------------------------------------------------- */
 
 .sync-modal__accept-btn {
   display: inline-block;
-  padding: 2px 7px;
+  padding: 4px 10px;
   border: 1px solid var(--panel-border);
-  border-radius: 3px;
+  border-radius: 4px;
   background: transparent;
   color: var(--editor-fg);
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.2px;
   cursor: pointer;
-  opacity: 0.5;
-  transition: all 0.1s;
+  opacity: 0.6;
+  transition: all 0.15s;
   white-space: nowrap;
 }
 
 .sync-modal__accept-btn:hover {
   opacity: 1;
-  background: var(--selection-bg);
+}
+
+/* Logical hover preview */
+.sync-modal__accept-btn--logical:hover {
+  background: rgba(96, 165, 250, 0.12);
+  border-color: var(--stage-logical, #60a5fa);
+  color: var(--stage-logical, #60a5fa);
+}
+
+/* Physical hover preview */
+.sync-modal__accept-btn--physical:hover {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: var(--stage-physical, #22c55e);
+  color: var(--stage-physical, #22c55e);
 }
 
 /* Logical accept — blue when selected */
@@ -376,6 +489,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   background: var(--stage-logical, #60a5fa);
   border-color: var(--stage-logical, #60a5fa);
   color: var(--button-fg, #fff);
+  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.3);
 }
 
 /* Physical accept — green when selected */
@@ -384,6 +498,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   background: var(--stage-physical, #22c55e);
   border-color: var(--stage-physical, #22c55e);
   color: var(--button-fg, #fff);
+  box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.3);
 }
 
 /* ---------------------------------------------------------------------------
@@ -404,7 +519,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   font-size: 11px;
   cursor: pointer;
   opacity: 0.75;
-  transition: opacity 0.1s;
+  transition: opacity 0.15s;
   padding: 0;
   line-height: 1;
 }
@@ -428,16 +543,16 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 .sync-modal__model-bulk-btn {
   display: block;
   margin-top: 4px;
-  padding: 1px 6px;
+  padding: 2px 8px;
   border: 1px solid var(--panel-border);
   border-radius: 3px;
   background: transparent;
   color: var(--editor-fg);
-  font-size: 9px;
+  font-size: 10px;
   font-weight: 600;
   cursor: pointer;
-  opacity: 0.45;
-  transition: all 0.1s;
+  opacity: 0.55;
+  transition: all 0.15s;
   white-space: nowrap;
   letter-spacing: 0.2px;
 }
@@ -453,7 +568,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 
 .sync-modal__model-name {
   font-weight: 600;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--editor-fg);
   white-space: nowrap;
   overflow: hidden;
@@ -461,12 +576,18 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 }
 
 .sync-modal__resolved-badge {
-  font-size: 9px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
   font-weight: 600;
   color: var(--stage-physical, #22c55e);
   letter-spacing: 0.2px;
   white-space: nowrap;
   flex-shrink: 0;
+  background: rgba(34, 197, 94, 0.1);
+  padding: 1px 7px;
+  border-radius: 3px;
 }
 
 .sync-modal__col-name {
@@ -475,15 +596,30 @@ tbody .sync-modal__row--model-header:not(:first-child) {
   color: var(--editor-fg);
 }
 
+/* Relationship labels — structured with hierarchy */
 .sync-modal__rel-label {
   font-family: var(--vscode-editor-font-family, monospace);
   font-size: 11px;
   color: var(--editor-fg);
 }
 
-.sync-modal__exists-check {
-  font-size: 13px;
-  font-weight: 700;
+.sync-modal__rel-model {
+  font-weight: 600;
+  color: var(--editor-fg);
+}
+
+.sync-modal__rel-sep {
+  opacity: 0.35;
+}
+
+.sync-modal__rel-col {
+  font-weight: 400;
+  opacity: 0.75;
+}
+
+.sync-modal__rel-arrow {
+  opacity: 0.35;
+  margin: 0 3px;
 }
 
 .sync-modal__exists-dot {
@@ -494,41 +630,52 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 .sync-modal__missing-dash {
   font-size: 11px;
   font-style: italic;
-  opacity: 0.7;
+  opacity: 0.65;
 }
 
-/* Status dot (model-level conflict indicator) */
-.sync-modal__model-status-dot {
-  display: inline-block;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
+/* ---------------------------------------------------------------------------
+   Status badges — replace tiny dots with readable pills
+   --------------------------------------------------------------------------- */
+
+.sync-modal__status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  white-space: nowrap;
   flex-shrink: 0;
+  line-height: 1.5;
 }
 
-.sync-modal__model-status-dot--extra {
-  background: var(--discrepancy-extra, #f59e0b);
+.sync-modal__status-badge--sm {
+  font-size: 8px;
+  padding: 0 5px;
+  line-height: 1.6;
 }
 
-.sync-modal__model-status-dot--missing {
-  background: var(--stage-ghost, #9ca3af);
+.sync-modal__status-badge--extra {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--discrepancy-extra, #f59e0b);
 }
 
-/* Column indicator dot */
-.sync-modal__col-dot {
-  display: inline-block;
-  width: 5px;
-  height: 5px;
-  border-radius: 1px;
-  margin-right: 4px;
-  vertical-align: middle;
-  flex-shrink: 0;
+.sync-modal__status-badge--missing {
+  background: var(--stage-ghost-bg, rgba(156, 163, 175, 0.08));
+  color: var(--stage-ghost, #9ca3af);
 }
 
-.sync-modal__col-dot--extra      { background: var(--discrepancy-extra, #f59e0b); }
-.sync-modal__col-dot--missing    { background: var(--stage-ghost, #9ca3af); }
-.sync-modal__col-dot--type-mismatch       { background: var(--discrepancy-mismatch, #f59e0b); }
-.sync-modal__col-dot--cardinality-mismatch { background: var(--discrepancy-mismatch, #f59e0b); }
+.sync-modal__status-badge--type-mismatch {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--discrepancy-mismatch, #ef4444);
+}
+
+.sync-modal__status-badge--cardinality-mismatch {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--discrepancy-mismatch, #ef4444);
+}
 
 /* ---------------------------------------------------------------------------
    Type-mismatch pill badges
@@ -536,7 +683,7 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 
 .sync-modal__type-pill {
   display: inline-block;
-  padding: 1px 5px;
+  padding: 1px 6px;
   border: 1px solid currentColor;
   border-radius: 3px;
   font-family: var(--vscode-editor-font-family, monospace);
@@ -560,13 +707,13 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 }
 
 .sync-modal__section-label {
-  padding: 8px 12px 5px;
-  font-size: 9px;
+  padding: 14px 14px 6px;
+  font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--editor-fg);
-  opacity: 0.45;
+  opacity: 0.5;
   border-top: 2px solid var(--panel-border);
 }
 
@@ -577,8 +724,83 @@ tbody .sync-modal__row--model-header:not(:first-child) {
 .sync-modal__footer {
   border-top: 1px solid var(--panel-border);
   flex-shrink: 0;
+  transition: background 0.3s ease;
+}
+
+.sync-modal__footer--ready {
+  background: var(--stage-physical-bg);
 }
 
 .sync-modal__footer .disc-panel__sync-footer {
-  padding: 10px 16px;
+  padding: 12px 20px;
+}
+
+/* ---------------------------------------------------------------------------
+   Resolved section — collapsed summary at bottom of table
+   --------------------------------------------------------------------------- */
+
+.sync-modal__resolved-section-header {
+  cursor: pointer;
+  border-top: 2px solid var(--panel-border);
+  transition: background 0.15s ease;
+}
+
+.sync-modal__resolved-section-header:hover {
+  background: var(--selection-bg);
+}
+
+.sync-modal__resolved-section-cell {
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sync-modal__resolved-section-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  background: transparent;
+  color: var(--editor-fg);
+  font-size: 10px;
+  cursor: pointer;
+  opacity: 0.6;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.sync-modal__resolved-section-badge {
+  font-size: 13px;
+  color: var(--stage-physical, #22c55e);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.sync-modal__resolved-section-text {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--editor-fg);
+  opacity: 0.6;
+}
+
+/* ---------------------------------------------------------------------------
+   Animations
+   --------------------------------------------------------------------------- */
+
+@keyframes sync-modal__fade-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes sync-modal__pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.3); }
+  50%      { box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.1); }
+}
+
+/* Pulse the CTA button when all resolved and plan not yet generated */
+.sync-modal__footer--ready .disc-panel__sync-footer-btn {
+  animation: sync-modal__pulse 2s ease-in-out infinite;
 }

--- a/webview/components/SyncMergeModal/SyncMergeModal.tsx
+++ b/webview/components/SyncMergeModal/SyncMergeModal.tsx
@@ -4,6 +4,12 @@
  * Four-column layout: [chevron] | Logical | Item | Physical
  * Model section headers contain bulk accept buttons in their stage cells.
  * Column rows use AcceptCell for individual per-column resolution.
+ *
+ * UI/UX principles:
+ * - Plain language: "Keep Logical" instead of arrows, "Apply Changes" instead of "Generate Sync Plan"
+ * - Status badges: readable pills instead of tiny dots
+ * - Action tooltips: each accept button explains what will happen
+ * - Completion feedback: banner + green footer when all resolved
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -15,10 +21,63 @@ import {
   modelKey,
   columnKey,
   relationshipKey,
+  deriveColumnAction,
+  deriveRelationshipAction,
 } from '../../../src/types/syncPlan';
 import type { ModelDiscrepancy, RelationshipDiscrepancy } from '../../../src/types/discrepancy';
 import type { GroundTruth } from '../../../src/types/syncPlan';
+import type { Stage } from '../../../src/types/semantic';
 import './SyncMergeModal.css';
+
+// ---------------------------------------------------------------------------
+// actionToHint — maps action codes to user-friendly tooltip descriptions
+// ---------------------------------------------------------------------------
+
+function actionToHint(action: string | null): string {
+  switch (action) {
+    case 'add-to-logical':                       return 'Will add this model to your logical design';
+    case 'remove-from-logical':                  return 'Will remove this model from your logical design';
+    case 'add-to-physical':                      return 'Will add this model to dbt (requires compile)';
+    case 'remove-from-physical':                 return 'Will remove this model from dbt';
+    case 'add-column-to-logical':                return 'Will add this column to your logical design';
+    case 'remove-column-from-logical':           return 'Will remove this column from your logical design';
+    case 'add-column-to-physical':               return 'Will add this column in dbt schema';
+    case 'remove-column-from-physical':          return 'Will remove this column from dbt schema';
+    case 'update-type-in-logical':               return 'Will update the data type in your logical design';
+    case 'update-type-in-physical':              return 'Will update the data type in dbt schema';
+    case 'add-relationship-to-logical':          return 'Will add this relationship to your logical design';
+    case 'remove-relationship-from-logical':     return 'Will remove this relationship from your logical design';
+    case 'add-relationship-test-to-physical':    return 'Will add a dbt relationship test';
+    case 'remove-relationship-test-from-physical': return 'Will remove the dbt relationship test';
+    case 'update-cardinality-in-logical':        return 'Will update cardinality in your logical design';
+    case 'update-cardinality-in-physical':       return 'Will update cardinality in dbt';
+    default:                                     return 'No changes needed';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// statusBadgeText helpers
+// ---------------------------------------------------------------------------
+
+function modelStatusText(status: string, sourceStage: string, targetStage: string): string {
+  if (status === 'extra') return `Only in ${stageName(sourceStage)}`;
+  if (status === 'missing') return `Only in ${stageName(targetStage)}`;
+  return status;
+}
+
+function columnStatusText(status: string): string {
+  if (status === 'extra') return 'New';
+  if (status === 'missing') return 'Missing';
+  if (status === 'type-mismatch') return 'Type diff';
+  return status;
+}
+
+function relStatusText(status: string): string {
+  if (status === 'extra') return 'New';
+  if (status === 'missing') return 'Missing';
+  if (status === 'cardinality-mismatch') return 'Cardinality diff';
+  return status;
+}
 
 // ---------------------------------------------------------------------------
 // AcceptCell — used only for column and relationship rows
@@ -29,14 +88,19 @@ interface AcceptCellProps {
   selectionKey: string;
   children: React.ReactNode;
   valueColor?: string;
+  hint?: string;
 }
 
-function AcceptCell({ side, selectionKey, children, valueColor }: AcceptCellProps) {
+function AcceptCell({ side, selectionKey, children, valueColor, hint }: AcceptCellProps) {
   const choice = useEditorStore((s) => s.syncSelections[selectionKey] ?? null);
   const setSyncSelection = useEditorStore((s) => s.setSyncSelection);
 
   const isSelected = choice === side;
   const isOtherSelected = choice !== null && choice !== side;
+
+  const label = isSelected
+    ? `Keeping ${stageName(side)}`
+    : `Keep ${stageName(side)}`;
 
   return (
     <td className={`sync-modal__cell sync-modal__cell--stage${isSelected ? ' sync-modal__cell--selected' : ''}${isOtherSelected ? ' sync-modal__cell--rejected' : ''}`}>
@@ -46,8 +110,9 @@ function AcceptCell({ side, selectionKey, children, valueColor }: AcceptCellProp
       <button
         className={`sync-modal__accept-btn sync-modal__accept-btn--${side}${isSelected ? ' sync-modal__accept-btn--selected' : ''}`}
         onClick={() => setSyncSelection(selectionKey, side)}
+        title={hint}
       >
-        {side === 'logical' ? '← Logical' : 'Physical →'}
+        {label}
       </button>
     </td>
   );
@@ -90,7 +155,7 @@ function ModelRow({ model, sourceStage, targetStage, isCollapsed, hasFoldableCon
   const chevronCell = (
     <td
       className="sync-modal__cell sync-modal__cell--chevron"
-      style={{ borderLeft: `3px solid ${accentColor}` }}
+      style={{ borderLeft: `4px solid ${accentColor}` }}
     >
       {hasFoldableContent && (
         <button
@@ -104,16 +169,18 @@ function ModelRow({ model, sourceStage, targetStage, isCollapsed, hasFoldableCon
     </td>
   );
 
-  // Item cell — just the model name and resolved badge
+  // Item cell — model name, status badge, and resolved badge
   const itemCell = (
     <td className="sync-modal__cell sync-modal__cell--item">
       <div className="sync-modal__model-item-row">
         {model.status !== 'matched' && (
-          <span className={`sync-modal__model-status-dot sync-modal__model-status-dot--${model.status}`} />
+          <span className={`sync-modal__status-badge sync-modal__status-badge--${model.status}`}>
+            {modelStatusText(model.status, sourceStage, targetStage)}
+          </span>
         )}
         <span className="sync-modal__model-name">{model.name}</span>
         {allResolved && (
-          <span className="sync-modal__resolved-badge">✓ resolved</span>
+          <span className="sync-modal__resolved-badge">Resolved</span>
         )}
       </div>
     </td>
@@ -124,7 +191,7 @@ function ModelRow({ model, sourceStage, targetStage, isCollapsed, hasFoldableCon
     const isSource = side === 'logical';
     const stageColor = STAGE_HEX[isSource ? sourceStage : targetStage];
 
-    // Existence indicator for conflicted models only (no tick for matched)
+    // Existence indicator for conflicted models only
     let existenceContent: React.ReactNode = null;
     if (model.status !== 'matched') {
       const inSource = model.status === 'extra';
@@ -141,9 +208,9 @@ function ModelRow({ model, sourceStage, targetStage, isCollapsed, hasFoldableCon
           <button
             className="sync-modal__model-bulk-btn"
             onClick={handleBulk(side)}
-            title={`Accept all ${side} for this model`}
+            title={`Keep all ${stageName(side)} for ${model.name}`}
           >
-            {side === 'logical' ? '← All' : 'All →'}
+            Keep all
           </button>
         )}
       </td>
@@ -183,6 +250,10 @@ function ColumnRow({ modelName, col, sourceStage, targetStage }: ColumnRowProps)
 
   const key = columnKey(modelName, col.name);
 
+  // Compute action hints for tooltips
+  const logicalHint = actionToHint(deriveColumnAction(col.status as 'extra' | 'missing' | 'type-mismatch', 'logical', sourceStage as Stage));
+  const physicalHint = actionToHint(deriveColumnAction(col.status as 'extra' | 'missing' | 'type-mismatch', 'physical', sourceStage as Stage));
+
   let sourceContent: React.ReactNode;
   let targetContent: React.ReactNode;
   let sourceColor: string | undefined;
@@ -215,14 +286,16 @@ function ColumnRow({ modelName, col, sourceStage, targetStage }: ColumnRowProps)
   return (
     <tr className={`sync-modal__row sync-modal__row--column sync-modal__row--conflict sync-modal__row--${col.status}`}>
       <td className="sync-modal__cell sync-modal__cell--chevron" />
-      <AcceptCell side="logical" selectionKey={key} valueColor={sourceColor}>
+      <AcceptCell side="logical" selectionKey={key} valueColor={sourceColor} hint={logicalHint}>
         {sourceContent}
       </AcceptCell>
       <td className="sync-modal__cell sync-modal__cell--item sync-modal__cell--col-item">
-        <span className={`sync-modal__col-dot sync-modal__col-dot--${col.status}`} />
+        <span className={`sync-modal__status-badge sync-modal__status-badge--sm sync-modal__status-badge--${col.status}`}>
+          {columnStatusText(col.status)}
+        </span>
         <span className="sync-modal__col-name">{col.name}</span>
       </td>
-      <AcceptCell side="physical" selectionKey={key} valueColor={targetColor}>
+      <AcceptCell side="physical" selectionKey={key} valueColor={targetColor} hint={physicalHint}>
         {targetContent}
       </AcceptCell>
     </tr>
@@ -235,7 +308,11 @@ function ColumnRow({ modelName, col, sourceStage, targetStage }: ColumnRowProps)
 
 function RelationshipRow({ rel, sourceStage, targetStage }: { rel: RelationshipDiscrepancy; sourceStage: string; targetStage: string }) {
   const key = relationshipKey(rel.fromModel, rel.fromColumn, rel.toModel, rel.toColumn);
-  const label = `${rel.fromModel}.${rel.fromColumn} → ${rel.toModel}.${rel.toColumn}`;
+
+  // Compute action hints for tooltips
+  const relStatus = rel.status === 'cardinality-mismatch' ? 'cardinality-mismatch' : rel.status;
+  const logicalHint = actionToHint(deriveRelationshipAction(relStatus as 'extra' | 'missing' | 'cardinality-mismatch', 'logical', sourceStage as Stage));
+  const physicalHint = actionToHint(deriveRelationshipAction(relStatus as 'extra' | 'missing' | 'cardinality-mismatch', 'physical', sourceStage as Stage));
 
   let sourceContent: React.ReactNode;
   let targetContent: React.ReactNode;
@@ -254,12 +331,22 @@ function RelationshipRow({ rel, sourceStage, targetStage }: { rel: RelationshipD
   return (
     <tr className={`sync-modal__row sync-modal__row--conflict sync-modal__row--${rel.status === 'cardinality-mismatch' ? 'mismatch' : rel.status}`}>
       <td className="sync-modal__cell sync-modal__cell--chevron" />
-      <AcceptCell side="logical" selectionKey={key}>{sourceContent}</AcceptCell>
+      <AcceptCell side="logical" selectionKey={key} hint={logicalHint}>{sourceContent}</AcceptCell>
       <td className="sync-modal__cell sync-modal__cell--item">
-        <span className={`sync-modal__col-dot sync-modal__col-dot--${rel.status === 'cardinality-mismatch' ? 'type-mismatch' : rel.status}`} />
-        <span className="sync-modal__rel-label">{label}</span>
+        <span className={`sync-modal__status-badge sync-modal__status-badge--sm sync-modal__status-badge--${rel.status === 'cardinality-mismatch' ? 'cardinality-mismatch' : rel.status}`}>
+          {relStatusText(rel.status)}
+        </span>
+        <span className="sync-modal__rel-label">
+          <span className="sync-modal__rel-model">{rel.fromModel}</span>
+          <span className="sync-modal__rel-sep">.</span>
+          <span className="sync-modal__rel-col">{rel.fromColumn}</span>
+          <span className="sync-modal__rel-arrow">→</span>
+          <span className="sync-modal__rel-model">{rel.toModel}</span>
+          <span className="sync-modal__rel-sep">.</span>
+          <span className="sync-modal__rel-col">{rel.toColumn}</span>
+        </span>
       </td>
-      <AcceptCell side="physical" selectionKey={key}>{targetContent}</AcceptCell>
+      <AcceptCell side="physical" selectionKey={key} hint={physicalHint}>{targetContent}</AcceptCell>
     </tr>
   );
 }
@@ -279,19 +366,53 @@ interface ModelRowGroupProps {
 
 function ModelRowGroup({ model, conflictCols, sourceStage, targetStage, isCollapsed, onToggle }: ModelRowGroupProps) {
   const syncSelections = useEditorStore((s) => s.syncSelections);
+  const setSyncSelection = useEditorStore((s) => s.setSyncSelection);
   const hasFoldableContent = conflictCols.length > 0;
+
+  const mKey = model.status !== 'matched' ? modelKey(model.name) : null;
+
+  const columnKeys = useMemo(
+    () => conflictCols.map((col) => columnKey(model.name, col.name)),
+    [model.name, conflictCols],
+  );
 
   const modelSyncKeys = useMemo(() => {
     const keys: string[] = [];
-    if (model.status !== 'matched') keys.push(modelKey(model.name));
-    for (const col of conflictCols) keys.push(columnKey(model.name, col.name));
+    if (mKey) keys.push(mKey);
+    keys.push(...columnKeys);
     return keys;
-  }, [model, conflictCols]);
+  }, [mKey, columnKeys]);
 
   const allResolved = useMemo(
     () => modelSyncKeys.length > 0 && modelSyncKeys.every((k) => syncSelections[k]),
     [modelSyncKeys, syncSelections],
   );
+
+  // Auto-resolve the model key when all column keys are resolved.
+  // When a model is extra/missing, it has both a model key and column keys.
+  // Users resolve columns individually but never explicitly resolve the model key,
+  // so we infer it: use the majority column selection direction, or default to the
+  // side the model exists on.
+  const setSyncSelectionRef = useRef(setSyncSelection);
+  useEffect(() => { setSyncSelectionRef.current = setSyncSelection; });
+
+  useEffect(() => {
+    if (!mKey || columnKeys.length === 0) return;
+    // Skip if model key is already set, or if not all columns are resolved yet
+    if (syncSelections[mKey]) return;
+    const allColsResolved = columnKeys.every((k) => syncSelections[k]);
+    if (!allColsResolved) return;
+
+    // Infer direction from column selections — majority wins
+    let logCount = 0;
+    let physCount = 0;
+    for (const k of columnKeys) {
+      if (syncSelections[k] === 'logical') logCount++;
+      else if (syncSelections[k] === 'physical') physCount++;
+    }
+    const inferred: GroundTruth = logCount >= physCount ? 'logical' : 'physical';
+    setSyncSelectionRef.current(mKey, inferred);
+  }, [mKey, columnKeys, syncSelections]);
 
   // Auto-collapse after a short delay when all items in this model are resolved
   const prevAllResolvedRef = useRef(false);
@@ -345,6 +466,8 @@ export function SyncMergeModal() {
   const setSyncSelectionBulk = useEditorStore((s) => s.setSyncSelectionBulk);
 
   const [collapsedModels, setCollapsedModels] = useState<Set<string>>(new Set());
+  const [hideResolved, setHideResolved] = useState(true);
+  const [resolvedSectionOpen, setResolvedSectionOpen] = useState(false);
 
   const toggleCollapsed = useCallback((modelName: string) => {
     setCollapsedModels((prev) => {
@@ -385,6 +508,57 @@ export function SyncMergeModal() {
     [allSyncKeys, syncSelections],
   );
 
+  // Determine which models are fully resolved (all their sync keys have selections)
+  const modelResolutionStatus = useMemo(() => {
+    const status = new Map<string, boolean>();
+    for (const m of models) {
+      const keys: string[] = [];
+      if (m.status !== 'matched') keys.push(modelKey(m.name));
+      for (const c of m.columns) {
+        if (c.status !== 'matched') keys.push(columnKey(m.name, c.name));
+      }
+      // A model is "resolved" if it has sync keys and all are selected
+      status.set(m.name, keys.length > 0 && keys.every((k) => syncSelections[k]));
+    }
+    return status;
+  }, [models, syncSelections]);
+
+  // Determine which relationships are resolved
+  const relResolutionStatus = useMemo(() => {
+    const status = new Map<string, boolean>();
+    for (const r of relsWithIssues) {
+      const k = relationshipKey(r.fromModel, r.fromColumn, r.toModel, r.toColumn);
+      status.set(k, !!syncSelections[k]);
+    }
+    return status;
+  }, [relsWithIssues, syncSelections]);
+
+  // Split models and relationships into unresolved / resolved when hiding
+  const { unresolvedModels, resolvedModels } = useMemo(() => {
+    if (!hideResolved) return { unresolvedModels: models, resolvedModels: [] as ModelDiscrepancy[] };
+    const unresolved: ModelDiscrepancy[] = [];
+    const resolved: ModelDiscrepancy[] = [];
+    for (const m of models) {
+      if (modelResolutionStatus.get(m.name)) resolved.push(m);
+      else unresolved.push(m);
+    }
+    return { unresolvedModels: unresolved, resolvedModels: resolved };
+  }, [models, hideResolved, modelResolutionStatus]);
+
+  const { unresolvedRels, resolvedRels } = useMemo(() => {
+    if (!hideResolved) return { unresolvedRels: relsWithIssues, resolvedRels: [] as RelationshipDiscrepancy[] };
+    const unresolved: RelationshipDiscrepancy[] = [];
+    const resolved: RelationshipDiscrepancy[] = [];
+    for (const r of relsWithIssues) {
+      const k = relationshipKey(r.fromModel, r.fromColumn, r.toModel, r.toColumn);
+      if (relResolutionStatus.get(k)) resolved.push(r);
+      else unresolved.push(r);
+    }
+    return { unresolvedRels: unresolved, resolvedRels: resolved };
+  }, [relsWithIssues, hideResolved, relResolutionStatus]);
+
+  const totalHiddenCount = resolvedModels.length + resolvedRels.length;
+
   const progressPct = allSyncKeys.length > 0 ? (resolvedCount / allSyncKeys.length) * 100 : 0;
   const allDone = resolvedCount === allSyncKeys.length && allSyncKeys.length > 0;
 
@@ -394,23 +568,12 @@ export function SyncMergeModal() {
     [allSyncKeys, setSyncSelectionBulk],
   );
 
-  // Collapse all models that are fully resolved
-  const handleFoldResolved = useCallback(() => {
-    setCollapsedModels((prev) => {
-      const next = new Set(prev);
-      for (const m of models) {
-        const keys: string[] = [];
-        if (m.status !== 'matched') keys.push(modelKey(m.name));
-        for (const c of m.columns) {
-          if (c.status !== 'matched') keys.push(columnKey(m.name, c.name));
-        }
-        if (keys.length > 0 && keys.every((k) => syncSelections[k])) {
-          next.add(m.name);
-        }
-      }
-      return next;
+  const handleToggleHideResolved = useCallback(() => {
+    setHideResolved((prev) => {
+      if (!prev) setResolvedSectionOpen(false); // collapse the section when enabling hide
+      return !prev;
     });
-  }, [models, syncSelections]);
+  }, []);
 
   if (!syncMode || !discrepancyReport) return null;
 
@@ -420,40 +583,73 @@ export function SyncMergeModal() {
   return (
     <>
       <div className="sync-modal__backdrop" onClick={handleClose} />
-      <div className="sync-modal" role="dialog" aria-modal="true" aria-label="Sync reconciliation">
+      <div className="sync-modal" role="dialog" aria-modal="true" aria-label="Resolve differences">
 
-        {/* Header */}
+        {/* Header — title + explanatory subtitle */}
         <div className="sync-modal__header">
-          <span className="sync-modal__header-title">
-            <span className="sync-modal__header-icon">⊕</span>
-            <span className="sync-modal__header-domain">{domain}</span>
-            <span className="sync-modal__header-sep">·</span>
-            <span className="sync-modal__header-stage" style={{ color: STAGE_HEX[sourceStage] }}>{sourceName}</span>
-            <span className="sync-modal__header-arrow">→</span>
-            <span className="sync-modal__header-stage" style={{ color: STAGE_HEX[targetStage] }}>{targetName}</span>
-          </span>
+          <div className="sync-modal__header-content">
+            <div className="sync-modal__header-title-row">
+              <span className="sync-modal__header-icon">⇄</span>
+              <span className="sync-modal__header-domain">{domain}</span>
+            </div>
+            <p className="sync-modal__header-subtitle">
+              Choose which version to keep for each difference between{' '}
+              <strong style={{ color: STAGE_HEX[sourceStage] }}>{sourceName}</strong>
+              {' '}and{' '}
+              <strong style={{ color: STAGE_HEX[targetStage] }}>{targetName}</strong>.
+            </p>
+          </div>
           <button className="sync-modal__close" onClick={handleClose} aria-label="Exit sync mode">&times;</button>
         </div>
 
         <StalenessWarning />
 
-        {/* Bulk toolbar */}
+        {/* Toolbar — plain-language bulk actions */}
         <div className="sync-modal__toolbar">
-          <button className="sync-modal__bulk-btn" onClick={handleBulk('logical')}>← All {sourceName}</button>
-          <button className="sync-modal__bulk-btn" onClick={handleBulk('physical')}>All {targetName} →</button>
-          <button className="sync-modal__bulk-btn" onClick={handleFoldResolved} title="Collapse all fully resolved model sections">Fold resolved</button>
+          <button className="sync-modal__bulk-btn sync-modal__bulk-btn--logical" onClick={handleBulk('logical')}>
+            Keep all {sourceName}
+          </button>
+          <button className="sync-modal__bulk-btn sync-modal__bulk-btn--physical" onClick={handleBulk('physical')}>
+            Keep all {targetName}
+          </button>
+          <span className="sync-modal__toolbar-sep" />
+          <button
+            className={`sync-modal__bulk-btn${hideResolved ? ' sync-modal__bulk-btn--active' : ''}`}
+            onClick={handleToggleHideResolved}
+            title={hideResolved ? 'Show all items including resolved' : 'Move resolved items to the bottom and collapse them'}
+          >
+            {hideResolved ? 'Show all' : 'Hide resolved'}
+          </button>
           <span className="sync-modal__toolbar-count">
             {resolvedCount} of {allSyncKeys.length} resolved
           </span>
         </div>
 
-        {/* Progress bar */}
-        <div className="sync-modal__progress">
-          <div
-            className={`sync-modal__progress-fill${allDone ? ' sync-modal__progress-fill--done' : ''}`}
-            style={{ width: `${progressPct}%` }}
-          />
+        {/* Progress section — labeled bar with status */}
+        <div className="sync-modal__progress-section">
+          <div className="sync-modal__progress-label">
+            <span className="sync-modal__progress-label-text">
+              {resolvedCount} of {allSyncKeys.length} difference{allSyncKeys.length !== 1 ? 's' : ''} resolved
+            </span>
+            {allDone && <span className="sync-modal__progress-done-badge">Ready to apply</span>}
+          </div>
+          <div className="sync-modal__progress">
+            <div
+              className={`sync-modal__progress-fill${allDone ? ' sync-modal__progress-fill--done' : ''}`}
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
         </div>
+
+        {/* Completion banner — appears when all resolved */}
+        {allDone && (
+          <div className="sync-modal__completion-banner">
+            <span className="sync-modal__completion-icon">✓</span>
+            <span className="sync-modal__completion-text">
+              All differences resolved. Click <strong>Apply Changes</strong> below to continue.
+            </span>
+          </div>
+        )}
 
         {/* Table */}
         <div className="sync-modal__table-wrap">
@@ -467,19 +663,18 @@ export function SyncMergeModal() {
             <thead className="sync-modal__thead">
               <tr>
                 <th className="sync-modal__th sync-modal__th--chevron" />
-                <th className="sync-modal__th sync-modal__th--stage" style={{ color: STAGE_HEX[sourceStage] }}>
+                <th className="sync-modal__th sync-modal__th--stage sync-modal__th--logical" style={{ color: STAGE_HEX[sourceStage] }}>
                   {sourceName}
-                  <span className="sync-modal__th-sub">(current)</span>
                 </th>
-                <th className="sync-modal__th sync-modal__th--item">Item</th>
-                <th className="sync-modal__th sync-modal__th--stage" style={{ color: STAGE_HEX[targetStage] }}>
+                <th className="sync-modal__th sync-modal__th--item">Difference</th>
+                <th className="sync-modal__th sync-modal__th--stage sync-modal__th--physical" style={{ color: STAGE_HEX[targetStage] }}>
                   {targetName}
-                  <span className="sync-modal__th-sub">(target)</span>
                 </th>
               </tr>
             </thead>
             <tbody>
-              {models.map((model) => {
+              {/* Unresolved models — always shown at top */}
+              {unresolvedModels.map((model) => {
                 const conflictCols = model.columns.filter((c) => c.status !== 'matched');
                 return (
                   <ModelRowGroup
@@ -493,14 +688,58 @@ export function SyncMergeModal() {
                   />
                 );
               })}
-              {relsWithIssues.length > 0 && (
+
+              {/* Unresolved relationships */}
+              {unresolvedRels.length > 0 && (
                 <>
                   <tr className="sync-modal__section-header-row">
                     <td colSpan={4} className="sync-modal__section-label">Relationships</td>
                   </tr>
-                  {relsWithIssues.map((r) => (
+                  {unresolvedRels.map((r) => (
                     <RelationshipRow
                       key={`${r.fromModel}.${r.fromColumn}-${r.toModel}.${r.toColumn}`}
+                      rel={r}
+                      sourceStage={sourceStage}
+                      targetStage={targetStage}
+                    />
+                  ))}
+                </>
+              )}
+
+              {/* Resolved section — collapsed summary at bottom when hideResolved is on */}
+              {hideResolved && totalHiddenCount > 0 && (
+                <>
+                  <tr
+                    className="sync-modal__resolved-section-header"
+                    onClick={() => setResolvedSectionOpen((prev) => !prev)}
+                  >
+                    <td colSpan={4} className="sync-modal__resolved-section-cell">
+                      <button className="sync-modal__resolved-section-toggle" aria-label={resolvedSectionOpen ? 'Collapse resolved items' : 'Expand resolved items'}>
+                        {resolvedSectionOpen ? '▼' : '▶'}
+                      </button>
+                      <span className="sync-modal__resolved-section-badge">✓</span>
+                      <span className="sync-modal__resolved-section-text">
+                        {totalHiddenCount} resolved item{totalHiddenCount !== 1 ? 's' : ''}
+                      </span>
+                    </td>
+                  </tr>
+                  {resolvedSectionOpen && resolvedModels.map((model) => {
+                    const conflictCols = model.columns.filter((c) => c.status !== 'matched');
+                    return (
+                      <ModelRowGroup
+                        key={model.name}
+                        model={model}
+                        conflictCols={conflictCols}
+                        sourceStage={sourceStage}
+                        targetStage={targetStage}
+                        isCollapsed={collapsedModels.has(model.name)}
+                        onToggle={() => toggleCollapsed(model.name)}
+                      />
+                    );
+                  })}
+                  {resolvedSectionOpen && resolvedRels.length > 0 && resolvedRels.map((r) => (
+                    <RelationshipRow
+                      key={`resolved-${r.fromModel}.${r.fromColumn}-${r.toModel}.${r.toColumn}`}
                       rel={r}
                       sourceStage={sourceStage}
                       targetStage={targetStage}
@@ -513,7 +752,7 @@ export function SyncMergeModal() {
         </div>
 
         {/* Footer */}
-        <div className="sync-modal__footer">
+        <div className={`sync-modal__footer${allDone ? ' sync-modal__footer--ready' : ''}`}>
           <SyncFooter totalKeys={allSyncKeys.length} />
         </div>
       </div>

--- a/webview/components/SyncMergeModal/SyncMergeModal.tsx
+++ b/webview/components/SyncMergeModal/SyncMergeModal.tsx
@@ -33,31 +33,39 @@ import './SyncMergeModal.css';
 // actionToHint — maps action codes to user-friendly tooltip descriptions
 // ---------------------------------------------------------------------------
 
+const ACTION_HINTS: Record<string, string> = {
+  'add-to-logical':                        'Will add this model to your logical design',
+  'remove-from-logical':                   'Will remove this model from your logical design',
+  'add-to-physical':                       'Will add this model to dbt (requires compile)',
+  'remove-from-physical':                  'Will remove this model from dbt',
+  'add-column-to-logical':                 'Will add this column to your logical design',
+  'remove-column-from-logical':            'Will remove this column from your logical design',
+  'add-column-to-physical':                'Will add this column in dbt schema',
+  'remove-column-from-physical':           'Will remove this column from dbt schema',
+  'update-type-in-logical':                'Will update the data type in your logical design',
+  'update-type-in-physical':               'Will update the data type in dbt schema',
+  'add-relationship-to-logical':           'Will add this relationship to your logical design',
+  'remove-relationship-from-logical':      'Will remove this relationship from your logical design',
+  'add-relationship-test-to-physical':     'Will add a dbt relationship test',
+  'remove-relationship-test-from-physical': 'Will remove the dbt relationship test',
+  'update-cardinality-in-logical':         'Will update cardinality in your logical design',
+  'update-cardinality-in-physical':        'Will update cardinality in dbt',
+};
+
 function actionToHint(action: string | null): string {
-  switch (action) {
-    case 'add-to-logical':                       return 'Will add this model to your logical design';
-    case 'remove-from-logical':                  return 'Will remove this model from your logical design';
-    case 'add-to-physical':                      return 'Will add this model to dbt (requires compile)';
-    case 'remove-from-physical':                 return 'Will remove this model from dbt';
-    case 'add-column-to-logical':                return 'Will add this column to your logical design';
-    case 'remove-column-from-logical':           return 'Will remove this column from your logical design';
-    case 'add-column-to-physical':               return 'Will add this column in dbt schema';
-    case 'remove-column-from-physical':          return 'Will remove this column from dbt schema';
-    case 'update-type-in-logical':               return 'Will update the data type in your logical design';
-    case 'update-type-in-physical':              return 'Will update the data type in dbt schema';
-    case 'add-relationship-to-logical':          return 'Will add this relationship to your logical design';
-    case 'remove-relationship-from-logical':     return 'Will remove this relationship from your logical design';
-    case 'add-relationship-test-to-physical':    return 'Will add a dbt relationship test';
-    case 'remove-relationship-test-from-physical': return 'Will remove the dbt relationship test';
-    case 'update-cardinality-in-logical':        return 'Will update cardinality in your logical design';
-    case 'update-cardinality-in-physical':       return 'Will update cardinality in dbt';
-    default:                                     return 'No changes needed';
-  }
+  return (action && ACTION_HINTS[action]) ?? 'No changes needed';
 }
 
 // ---------------------------------------------------------------------------
-// statusBadgeText helpers
+// Status badge text — maps discrepancy statuses to human labels
 // ---------------------------------------------------------------------------
+
+const ITEM_STATUS_TEXT: Record<string, string> = {
+  extra:                  'New',
+  missing:                'Missing',
+  'type-mismatch':        'Type diff',
+  'cardinality-mismatch': 'Cardinality diff',
+};
 
 function modelStatusText(status: string, sourceStage: string, targetStage: string): string {
   if (status === 'extra') return `Only in ${stageName(sourceStage)}`;
@@ -65,18 +73,36 @@ function modelStatusText(status: string, sourceStage: string, targetStage: strin
   return status;
 }
 
-function columnStatusText(status: string): string {
-  if (status === 'extra') return 'New';
-  if (status === 'missing') return 'Missing';
-  if (status === 'type-mismatch') return 'Type diff';
-  return status;
+function itemStatusText(status: string): string {
+  return ITEM_STATUS_TEXT[status] ?? status;
 }
 
-function relStatusText(status: string): string {
-  if (status === 'extra') return 'New';
-  if (status === 'missing') return 'Missing';
-  if (status === 'cardinality-mismatch') return 'Cardinality diff';
-  return status;
+// ---------------------------------------------------------------------------
+// Type narrowing helpers — filter out 'matched' with proper type narrowing
+// ---------------------------------------------------------------------------
+
+type ConflictColumnStatus = 'extra' | 'missing' | 'type-mismatch';
+type ConflictRelStatus = 'extra' | 'missing' | 'cardinality-mismatch';
+
+function isConflictColumnStatus(s: string): s is ConflictColumnStatus {
+  return s === 'extra' || s === 'missing' || s === 'type-mismatch';
+}
+
+function isConflictRelStatus(s: string): s is ConflictRelStatus {
+  return s === 'extra' || s === 'missing' || s === 'cardinality-mismatch';
+}
+
+// ---------------------------------------------------------------------------
+// splitByResolved — partitions an array into unresolved/resolved items
+// ---------------------------------------------------------------------------
+
+function splitByResolved<T>(items: T[], isResolved: (item: T) => boolean): { unresolved: T[]; resolved: T[] } {
+  const unresolved: T[] = [];
+  const resolved: T[] = [];
+  for (const item of items) {
+    (isResolved(item) ? resolved : unresolved).push(item);
+  }
+  return { unresolved, resolved };
 }
 
 // ---------------------------------------------------------------------------
@@ -250,9 +276,10 @@ function ColumnRow({ modelName, col, sourceStage, targetStage }: ColumnRowProps)
 
   const key = columnKey(modelName, col.name);
 
-  // Compute action hints for tooltips
-  const logicalHint = actionToHint(deriveColumnAction(col.status as 'extra' | 'missing' | 'type-mismatch', 'logical', sourceStage as Stage));
-  const physicalHint = actionToHint(deriveColumnAction(col.status as 'extra' | 'missing' | 'type-mismatch', 'physical', sourceStage as Stage));
+  // Compute action hints for tooltips (status is narrowed by the matched guard above)
+  const colStatus = isConflictColumnStatus(col.status) ? col.status : 'extra';
+  const logicalHint = actionToHint(deriveColumnAction(colStatus, 'logical', sourceStage as Stage));
+  const physicalHint = actionToHint(deriveColumnAction(colStatus, 'physical', sourceStage as Stage));
 
   let sourceContent: React.ReactNode;
   let targetContent: React.ReactNode;
@@ -291,7 +318,7 @@ function ColumnRow({ modelName, col, sourceStage, targetStage }: ColumnRowProps)
       </AcceptCell>
       <td className="sync-modal__cell sync-modal__cell--item sync-modal__cell--col-item">
         <span className={`sync-modal__status-badge sync-modal__status-badge--sm sync-modal__status-badge--${col.status}`}>
-          {columnStatusText(col.status)}
+          {itemStatusText(col.status)}
         </span>
         <span className="sync-modal__col-name">{col.name}</span>
       </td>
@@ -309,10 +336,10 @@ function ColumnRow({ modelName, col, sourceStage, targetStage }: ColumnRowProps)
 function RelationshipRow({ rel, sourceStage, targetStage }: { rel: RelationshipDiscrepancy; sourceStage: string; targetStage: string }) {
   const key = relationshipKey(rel.fromModel, rel.fromColumn, rel.toModel, rel.toColumn);
 
-  // Compute action hints for tooltips
-  const relStatus = rel.status === 'cardinality-mismatch' ? 'cardinality-mismatch' : rel.status;
-  const logicalHint = actionToHint(deriveRelationshipAction(relStatus as 'extra' | 'missing' | 'cardinality-mismatch', 'logical', sourceStage as Stage));
-  const physicalHint = actionToHint(deriveRelationshipAction(relStatus as 'extra' | 'missing' | 'cardinality-mismatch', 'physical', sourceStage as Stage));
+  // Compute action hints for tooltips (only called for non-matched relationships)
+  const relStatus = isConflictRelStatus(rel.status) ? rel.status : 'extra';
+  const logicalHint = actionToHint(deriveRelationshipAction(relStatus, 'logical', sourceStage as Stage));
+  const physicalHint = actionToHint(deriveRelationshipAction(relStatus, 'physical', sourceStage as Stage));
 
   let sourceContent: React.ReactNode;
   let targetContent: React.ReactNode;
@@ -334,7 +361,7 @@ function RelationshipRow({ rel, sourceStage, targetStage }: { rel: RelationshipD
       <AcceptCell side="logical" selectionKey={key} hint={logicalHint}>{sourceContent}</AcceptCell>
       <td className="sync-modal__cell sync-modal__cell--item">
         <span className={`sync-modal__status-badge sync-modal__status-badge--sm sync-modal__status-badge--${rel.status === 'cardinality-mismatch' ? 'cardinality-mismatch' : rel.status}`}>
-          {relStatusText(rel.status)}
+          {itemStatusText(rel.status)}
         </span>
         <span className="sync-modal__rel-label">
           <span className="sync-modal__rel-model">{rel.fromModel}</span>
@@ -403,7 +430,7 @@ function ModelRowGroup({ model, conflictCols, sourceStage, targetStage, isCollap
     const allColsResolved = columnKeys.every((k) => syncSelections[k]);
     if (!allColsResolved) return;
 
-    // Infer direction from column selections — majority wins
+    // Infer direction from column selections — majority wins, logical on tie
     let logCount = 0;
     let physCount = 0;
     for (const k of columnKeys) {
@@ -534,27 +561,17 @@ export function SyncMergeModal() {
   }, [relsWithIssues, syncSelections]);
 
   // Split models and relationships into unresolved / resolved when hiding
-  const { unresolvedModels, resolvedModels } = useMemo(() => {
-    if (!hideResolved) return { unresolvedModels: models, resolvedModels: [] as ModelDiscrepancy[] };
-    const unresolved: ModelDiscrepancy[] = [];
-    const resolved: ModelDiscrepancy[] = [];
-    for (const m of models) {
-      if (modelResolutionStatus.get(m.name)) resolved.push(m);
-      else unresolved.push(m);
-    }
-    return { unresolvedModels: unresolved, resolvedModels: resolved };
+  const { unresolved: unresolvedModels, resolved: resolvedModels } = useMemo(() => {
+    if (!hideResolved) return { unresolved: models, resolved: [] as ModelDiscrepancy[] };
+    return splitByResolved(models, (m) => !!modelResolutionStatus.get(m.name));
   }, [models, hideResolved, modelResolutionStatus]);
 
-  const { unresolvedRels, resolvedRels } = useMemo(() => {
-    if (!hideResolved) return { unresolvedRels: relsWithIssues, resolvedRels: [] as RelationshipDiscrepancy[] };
-    const unresolved: RelationshipDiscrepancy[] = [];
-    const resolved: RelationshipDiscrepancy[] = [];
-    for (const r of relsWithIssues) {
+  const { unresolved: unresolvedRels, resolved: resolvedRels } = useMemo(() => {
+    if (!hideResolved) return { unresolved: relsWithIssues, resolved: [] as RelationshipDiscrepancy[] };
+    return splitByResolved(relsWithIssues, (r) => {
       const k = relationshipKey(r.fromModel, r.fromColumn, r.toModel, r.toColumn);
-      if (relResolutionStatus.get(k)) resolved.push(r);
-      else unresolved.push(r);
-    }
-    return { unresolvedRels: unresolved, resolvedRels: resolved };
+      return !!relResolutionStatus.get(k);
+    });
   }, [relsWithIssues, hideResolved, relResolutionStatus]);
 
   const totalHiddenCount = resolvedModels.length + resolvedRels.length;

--- a/webview/styles/theme.css
+++ b/webview/styles/theme.css
@@ -70,12 +70,17 @@ body {
      ----------------------------------------------------------------------- */
 
   /* Logical stage — blue (detailed design) */
-  --stage-logical:    #60a5fa;
-  --stage-logical-bg: rgba(96, 165, 250, 0.08);
+  --stage-logical:       #60a5fa;
+  --stage-logical-bg:    rgba(96, 165, 250, 0.08);
+  --stage-logical-hover: rgba(96, 165, 250, 0.12);
+  --stage-logical-ring:  rgba(96, 165, 250, 0.3);
 
   /* Physical stage — green (built in dbt) */
-  --stage-physical:    #22c55e;
-  --stage-physical-bg: rgba(34, 197, 94, 0.08);
+  --stage-physical:       #22c55e;
+  --stage-physical-bg:    rgba(34, 197, 94, 0.08);
+  --stage-physical-hover: rgba(34, 197, 94, 0.12);
+  --stage-physical-ring:  rgba(34, 197, 94, 0.3);
+  --stage-physical-border: rgba(34, 197, 94, 0.2);
 
   /* Ghost/missing — grey (node not found in manifest or comparison stage) */
   --stage-ghost:    #9ca3af;


### PR DESCRIPTION
## Summary

- **Sync modal UX redesign** — replaces jargon with plain language, adds onboarding subtitle, status badges, action tooltips, completion banner, and hide-resolved toggle that moves resolved items to a collapsed bottom section
- **Data type normalisation** — case-insensitive comparison with alias mapping (varchar→string, integer→int, numeric→decimal, etc.) and whitespace normalisation for decimal precision params
- **Auto-resolve model key** — when all columns in an extra/missing model are individually resolved, the model key auto-resolves based on majority column selection direction

## Test plan

- [x] `npm run compile` — type-check clean
- [x] `npm run build` — builds clean
- [x] `npm run test` — 278 tests pass (10 new normalisation tests)
- [ ] Visual test in Extension Dev Host: open ppw-work-lot domain, compare physical vs logical, verify sync modal UX
- [ ] Verify data type mismatches are reduced (VARCHAR/string, integer/int treated as equivalent)
- [ ] Verify hide-resolved toggle collapses resolved items to bottom section
- [ ] Verify auto-resolve of model key when all columns resolved individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)