### PR TITLE
fix: prevent graph flicker when manifest is mid-write

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,6 +229,10 @@ export function activate(context: vscode.ExtensionContext): void {
               void vscode.window.showInformationMessage(
                 'dbt manifest updated. Graphs refreshed with latest model data.',
               );
+            } else {
+              void vscode.window.showWarningMessage(
+                'dbt manifest still updating — graph may show stale data. Run dbt compile to refresh.',
+              );
             }
           } catch (err) {
             console.error('[ERD Studio] Manifest retry failed:', err);
@@ -287,6 +291,7 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   context.subscriptions.push(
+    { dispose() { clearTimeout(manifestRetryTimeout); } },
     treeProvider,
     decorationProvider,
     layerDecorationProvider,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,9 +216,23 @@ export function activate(context: vscode.ExtensionContext): void {
     async () => {
       manifestService.invalidate();
       await editorProvider.refreshAllOpenDomains();
-      void vscode.window.showInformationMessage(
-        'dbt manifest updated. Graphs refreshed with latest model data.',
-      );
+
+      if (manifestService.isStale) {
+        // Manifest likely mid-write by dbt — retry once after 2s
+        setTimeout(async () => {
+          manifestService.invalidate();
+          await editorProvider.refreshAllOpenDomains();
+          if (!manifestService.isStale) {
+            void vscode.window.showInformationMessage(
+              'dbt manifest updated. Graphs refreshed with latest model data.',
+            );
+          }
+        }, 2000);
+      } else {
+        void vscode.window.showInformationMessage(
+          'dbt manifest updated. Graphs refreshed with latest model data.',
+        );
+      }
     },
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,20 +212,26 @@ export function activate(context: vscode.ExtensionContext): void {
   const fileWatcherService = new FileWatcherService(workspaceRoot);
 
   // Manifest changed → refresh open editors
+  let manifestRetryTimeout: ReturnType<typeof setTimeout> | undefined;
   const manifestChangedSubscription = fileWatcherService.onManifestChanged(
     async () => {
       manifestService.invalidate();
       await editorProvider.refreshAllOpenDomains();
 
       if (manifestService.isStale) {
-        // Manifest likely mid-write by dbt — retry once after 2s
-        setTimeout(async () => {
-          manifestService.invalidate();
-          await editorProvider.refreshAllOpenDomains();
-          if (!manifestService.isStale) {
-            void vscode.window.showInformationMessage(
-              'dbt manifest updated. Graphs refreshed with latest model data.',
-            );
+        // Manifest likely mid-write by dbt — deduplicate and retry once after 2s
+        clearTimeout(manifestRetryTimeout);
+        manifestRetryTimeout = setTimeout(async () => {
+          try {
+            manifestService.invalidate();
+            await editorProvider.refreshAllOpenDomains();
+            if (!manifestService.isStale) {
+              void vscode.window.showInformationMessage(
+                'dbt manifest updated. Graphs refreshed with latest model data.',
+              );
+            }
+          } catch (err) {
+            console.error('[ERD Studio] Manifest retry failed:', err);
           }
         }, 2000);
       } else {

--- a/src/services/manifestService.ts
+++ b/src/services/manifestService.ts
@@ -127,6 +127,7 @@ export class ManifestService {
     this.loadId++;
     this.cache = null;
     this.loadPromise = null;
+    this._isStale = false;
   }
 
   /**

--- a/src/services/manifestService.ts
+++ b/src/services/manifestService.ts
@@ -30,6 +30,21 @@ export class ManifestService {
   private loadId = 0;
 
   /**
+   * Last successfully parsed manifest data. Survives invalidate() so it can
+   * serve as a fallback when a parse fails (e.g. manifest mid-write by dbt).
+   */
+  private lastKnownGood: ManifestData | null = null;
+
+  /**
+   * True when the most recent loadManifest() returned stale/fallback data
+   * because the parse failed. Callers can check this to schedule a retry.
+   */
+  private _isStale = false;
+  get isStale(): boolean {
+    return this._isStale;
+  }
+
+  /**
    * Stream-parse the manifest and cache model data.
    * Returns cached data on subsequent calls until invalidate() is called.
    *
@@ -53,8 +68,24 @@ export class ManifestService {
       // Only cache if we haven't been invalidated during the parse
       if (currentLoadId === this.loadId) {
         this.cache = result;
+        this.lastKnownGood = result;
+        this._isStale = false;
       }
       return result;
+    } catch (err) {
+      // Parse failed — likely manifest is mid-write by dbt.
+      // Return stale data (or empty) so the graph stays visible.
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[ManifestService] Parse failed (file may be mid-write): ${message}. ` +
+        'Returning last known good data.',
+      );
+      const fallback = this.lastKnownGood ?? this.emptyManifest();
+      if (currentLoadId === this.loadId) {
+        this.cache = fallback;
+        this._isStale = true;
+      }
+      return fallback;
     } finally {
       if (currentLoadId === this.loadId) {
         this.loadPromise = null;
@@ -135,12 +166,7 @@ export class ManifestService {
         `[ManifestService] manifest.json not found at ${manifestPath}. ` +
         'Run "dbt compile" to generate it.'
       );
-      return {
-        models: new Map(),
-        relationshipTests: [],
-        uniqueColumns: new Map(),
-        compositeUniqueGroups: new Map(),
-      };
+      return this.emptyManifest();
     }
 
     const models = new Map<string, ManifestModelInfo>();
@@ -412,6 +438,15 @@ export class ManifestService {
    * Resolve the model name from a test node using attached_node (preferred)
    * or depends_on.nodes (fallback).
    */
+  private emptyManifest(): ManifestData {
+    return {
+      models: new Map(),
+      relationshipTests: [],
+      uniqueColumns: new Map(),
+      compositeUniqueGroups: new Map(),
+    };
+  }
+
   private resolveModelFromTestNode(node: Record<string, unknown>): string | undefined {
     // Prefer attached_node (dbt 1.0+)
     const attachedNode = node.attached_node as string | undefined;

--- a/src/services/manifestService.ts
+++ b/src/services/manifestService.ts
@@ -83,8 +83,8 @@ export class ManifestService {
       const fallback = this.lastKnownGood ?? this.emptyManifest();
       if (currentLoadId === this.loadId) {
         this.cache = fallback;
-        this._isStale = true;
       }
+      this._isStale = true; // set unconditionally — any parse failure means stale
       return fallback;
     } finally {
       if (currentLoadId === this.loadId) {

--- a/test/unit/manifestService.test.ts
+++ b/test/unit/manifestService.test.ts
@@ -206,10 +206,13 @@ describe('ManifestService', () => {
   });
 
   describe('error handling', () => {
-    it('rejects when manifest JSON is malformed', async () => {
-      await expect(
-        service.loadManifest(MALFORMED_PROJECT_PATH)
-      ).rejects.toThrow('Failed to parse manifest.json');
+    it('returns empty ManifestData when manifest JSON is malformed (stale-while-revalidate)', async () => {
+      // Malformed manifest should NOT reject — it returns empty/stale data
+      // so the graph stays visible during transient parse failures (e.g. mid-write)
+      const data = await service.loadManifest(MALFORMED_PROJECT_PATH);
+      expect(data.models.size).toBe(0);
+      expect(data.relationshipTests).toEqual([]);
+      expect(service.isStale).toBe(true);
     });
 
     it('handles models with missing columns field gracefully', async () => {


### PR DESCRIPTION
## Summary
- **ManifestService** now uses a stale-while-revalidate pattern: when `parseManifest()` fails (e.g. truncated JSON during `dbt compile`), it returns the last known good cache instead of throwing — so the graph stays visible
- **Extension watcher** retries once after 2s if the manifest was stale, and suppresses the "manifest updated" notification until the parse actually succeeds
- Added `isStale` getter and `lastKnownGood` two-tier cache to ManifestService; extracted `emptyManifest()` helper

## Problem
When dbt rebuilds `manifest.json`, the file watcher fires mid-write. The stream-json parser hits truncated JSON, throws, and `sendDomainData` forwards a `{ type: 'error' }` message to the webview — replacing the entire graph canvas with a red error div. The graph reappears seconds later when the file finishes writing and a second FS event triggers a successful parse.

## Test plan
- [x] `npm run compile` — type-checks pass
- [x] `npm run build` — builds cleanly  
- [x] `npx vitest run test/unit/manifestService.test.ts` — all 36 tests pass (updated malformed-manifest test to expect new stale-while-revalidate behaviour)
- [ ] Manual: open a domain visual, run `dbt compile` — graph should stay visible throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)