### PR TITLE
fix: only prompt reload when dbt_project.yml path config changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -286,10 +286,10 @@ export function activate(context: vscode.ExtensionContext): void {
     },
   );
 
-  // dbt_project.yml changed → suggest window reload
+  // dbt_project.yml path config changed → suggest window reload
   const projectChangedSubscription = fileWatcherService.onProjectConfigChanged(() => {
     void vscode.window.showWarningMessage(
-      'dbt_project.yml has changed. Some changes require a window reload to take effect.',
+      'dbt_project.yml path configuration changed (target-path / model-paths). A window reload is needed to pick up the new paths.',
       'Reload Window',
     ).then(action => {
       if (action === 'Reload Window') {

--- a/src/watchers/FileWatcherService.ts
+++ b/src/watchers/FileWatcherService.ts
@@ -4,7 +4,7 @@
  * Watches:
  * - target/manifest.json (dbt compile output) → triggers manifest cache invalidation
  * - erd-studio/**\/*.json (semantic domain files) → triggers tree and editor refresh
- * - dbt_project.yml (project configuration) → shows reload warning
+ * - dbt_project.yml (project configuration) → reload prompt only when path config changes
  *
  * All change events are debounced by 300ms to prevent rapid-fire triggers
  * during batch operations (e.g., git checkout, dbt compile).
@@ -18,6 +18,8 @@
  *   );
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 const DEBOUNCE_DELAY_MS = 300;
@@ -31,21 +33,26 @@ export class FileWatcherService implements vscode.Disposable {
   private readonly _onManifestChanged = new vscode.EventEmitter<void>();
   private readonly _onSemanticFileChanged = new vscode.EventEmitter<{ uri: vscode.Uri }>();
   private readonly _onSemanticFileDeleted = new vscode.EventEmitter<{ uri: vscode.Uri }>();
-  private readonly _onProjectConfigChanged = new vscode.EventEmitter<void>();
   private readonly _onLogicalModelChanged = new vscode.EventEmitter<{ uri: vscode.Uri; modelName: string }>();
   private readonly _onDbtYmlChanged = new vscode.EventEmitter<void>();
+  private readonly _onProjectConfigChanged = new vscode.EventEmitter<void>();
 
   // Public event subscriptions (consumers listen to these)
   readonly onManifestChanged = this._onManifestChanged.event;
   readonly onSemanticFileChanged = this._onSemanticFileChanged.event;
   readonly onSemanticFileDeleted = this._onSemanticFileDeleted.event;
-  readonly onProjectConfigChanged = this._onProjectConfigChanged.event;
   /** Fires when a YAML model file in erd-studio/logical-models/ changes. */
   readonly onLogicalModelChanged = this._onLogicalModelChanged.event;
   /** Fires when any dbt schema .yml/.yaml file under models/ changes. */
   readonly onDbtYmlChanged = this._onDbtYmlChanged.event;
+  /** Fires when target-path or model-paths change in dbt_project.yml. */
+  readonly onProjectConfigChanged = this._onProjectConfigChanged.event;
+
+  /** Snapshot of path-related keys from dbt_project.yml at startup. */
+  private lastProjectPaths: string;
 
   constructor(private readonly workspaceRoot: string) {
+    this.lastProjectPaths = this.readProjectPaths();
     this.setupManifestWatcher();
     this.setupSemanticWatcher();
     this.setupProjectConfigWatcher();
@@ -114,8 +121,9 @@ export class FileWatcherService implements vscode.Disposable {
   }
 
   /**
-   * Watch dbt_project.yml for changes.
-   * Project configuration changes may require a window reload.
+   * Watch dbt_project.yml for changes to path-related keys.
+   * Only fires onProjectConfigChanged when target-path or model-paths actually change,
+   * ignoring irrelevant edits (name, version, vars, etc.).
    */
   private setupProjectConfigWatcher(): void {
     const pattern = new vscode.RelativePattern(
@@ -126,16 +134,51 @@ export class FileWatcherService implements vscode.Disposable {
 
     const handleChange = () => {
       this.debounce('project', () => {
-        console.log('[FileWatcherService] dbt_project.yml changed');
-        this.safeFireEvent(() => this._onProjectConfigChanged.fire());
+        const current = this.readProjectPaths();
+        if (current !== this.lastProjectPaths) {
+          console.log('[FileWatcherService] dbt_project.yml path config changed');
+          this.lastProjectPaths = current;
+          this.safeFireEvent(() => this._onProjectConfigChanged.fire());
+        }
       });
     };
 
-    // Track event subscriptions for disposal
     this.subscriptions.push(watcher.onDidChange(handleChange));
-    // Note: Create/delete not common for dbt_project.yml
-
+    this.subscriptions.push(watcher.onDidCreate(handleChange));
     this.watchers.push(watcher);
+  }
+
+  /**
+   * Read path-related keys (target-path, model-paths) from dbt_project.yml.
+   * Uses simple line matching to avoid a full YAML dependency.
+   * Captures both inline values (`model-paths: ["models"]`) and block-sequence
+   * continuations (`model-paths:\n  - "models"\n  - "other"`).
+   * Returns a stable string for comparison; empty string if file is unreadable.
+   */
+  private readProjectPaths(): string {
+    try {
+      const content = fs.readFileSync(
+        path.join(this.workspaceRoot, 'dbt_project.yml'),
+        'utf-8',
+      );
+      const lines = content.split('\n');
+      const pathLines: string[] = [];
+      let collecting = false;
+      for (const line of lines) {
+        if (/^(target-path|model-paths)\s*:/.test(line)) {
+          pathLines.push(line.trim());
+          collecting = true;
+        } else if (collecting && /^\s+-/.test(line)) {
+          // Block-sequence continuation item (e.g. "  - models")
+          pathLines.push(line.trim());
+        } else if (collecting) {
+          collecting = false;
+        }
+      }
+      return pathLines.sort().join('\n');
+    } catch {
+      return '';
+    }
   }
 
   /**
@@ -252,8 +295,8 @@ export class FileWatcherService implements vscode.Disposable {
     this._onManifestChanged.dispose();
     this._onSemanticFileChanged.dispose();
     this._onSemanticFileDeleted.dispose();
-    this._onProjectConfigChanged.dispose();
     this._onLogicalModelChanged.dispose();
     this._onDbtYmlChanged.dispose();
+    this._onProjectConfigChanged.dispose();
   }
 }

--- a/test/unit/fileWatcherService.test.ts
+++ b/test/unit/fileWatcherService.test.ts
@@ -8,6 +8,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 
+// Mock fs before importing FileWatcherService
+let mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths: ["models"]\n';
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn((p: string, _enc?: string) => {
+      if (typeof p === 'string' && p.endsWith('dbt_project.yml')) {
+        return mockDbtProjectContent;
+      }
+      return actual.readFileSync(p as any, _enc as any);
+    }),
+  };
+});
+
 import { FileWatcherService } from '../../src/watchers/FileWatcherService';
 import {
   _clearMockFileWatchers,
@@ -24,6 +39,7 @@ describe('FileWatcherService', () => {
   beforeEach(() => {
     vi.clearAllTimers();
     _clearMockFileWatchers();
+    mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths: ["models"]\n';
     service = new FileWatcherService('/test/workspace');
   });
 
@@ -160,15 +176,99 @@ describe('FileWatcherService', () => {
   });
 
   describe('project config watcher', () => {
-    it('emits onProjectConfigChanged when dbt_project.yml changes', () => {
+    it('emits onProjectConfigChanged when target-path changes', () => {
       const listener = vi.fn();
       service.onProjectConfigChanged(listener);
 
+      // Project config watcher is the third one created (after manifest, semantic)
       const projectWatcher = _mockFileWatchers[2];
+
+      // Change the target-path
+      mockDbtProjectContent = 'name: my_project\ntarget-path: custom_target\nmodel-paths: ["models"]\n';
       projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
       vi.advanceTimersByTime(300);
 
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits onProjectConfigChanged when model-paths block-sequence items change', () => {
+      // Start with multi-line block-sequence form
+      _clearMockFileWatchers();
+      mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths:\n  - "models"\n  - "other"\n';
+      service = new FileWatcherService('/test/workspace');
+
+      const listener = vi.fn();
+      service.onProjectConfigChanged(listener);
+
+      const projectWatcher = _mockFileWatchers[2];
+
+      // Remove the "other" path entry
+      mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths:\n  - "models"\n';
+      projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
+      vi.advanceTimersByTime(300);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit onProjectConfigChanged when non-path config changes', () => {
+      const listener = vi.fn();
+      service.onProjectConfigChanged(listener);
+
+      const projectWatcher = _mockFileWatchers[2];
+
+      // Change only the project name — paths stay the same
+      mockDbtProjectContent = 'name: renamed_project\ntarget-path: target\nmodel-paths: ["models"]\n';
+      projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
+      vi.advanceTimersByTime(300);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not match indented path keys (e.g. under vars)', () => {
+      const listener = vi.fn();
+      service.onProjectConfigChanged(listener);
+
+      const projectWatcher = _mockFileWatchers[2];
+
+      // Add an indented model-paths under vars — should be ignored
+      mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths: ["models"]\nvars:\n  model-paths: "some_var"\n';
+      projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
+      vi.advanceTimersByTime(300);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('fires again when path config reverts to original', () => {
+      const listener = vi.fn();
+      service.onProjectConfigChanged(listener);
+
+      const projectWatcher = _mockFileWatchers[2];
+
+      // First change: different target-path
+      mockDbtProjectContent = 'name: my_project\ntarget-path: custom_target\nmodel-paths: ["models"]\n';
+      projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
+      vi.advanceTimersByTime(300);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Revert to original
+      mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths: ["models"]\n';
+      projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
+      vi.advanceTimersByTime(300);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not emit for seed-paths or snapshot-paths changes', () => {
+      const listener = vi.fn();
+      service.onProjectConfigChanged(listener);
+
+      const projectWatcher = _mockFileWatchers[2];
+
+      // Add seed-paths and snapshot-paths — should not trigger since extension doesn't use them
+      mockDbtProjectContent = 'name: my_project\ntarget-path: target\nmodel-paths: ["models"]\nseed-paths: ["seeds"]\nsnapshot-paths: ["snapshots"]\n';
+      projectWatcher._simulateChange(vscode.Uri.file('/test/workspace/dbt_project.yml'));
+      vi.advanceTimersByTime(300);
+
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- Replaced the blunt "reload on every save" watcher for `dbt_project.yml` with smart path-diffing that only prompts when `target-path` or `model-paths` actually change
- Fixed multi-line YAML block-sequence detection, indented key false-positives, and missing `onDidCreate` subscription
- Added 6 new test cases covering block-sequence arrays, indented keys, snapshot round-trips, and out-of-scope keys

## Test plan
- [x] `npm run compile` passes (no type errors)
- [x] `npm test` passes (310 tests, 0 failures)
- [x] Verified: changing `target-path` fires the reload prompt
- [x] Verified: changing `name`, `version`, `vars` does NOT fire
- [x] Verified: multi-line `model-paths` array changes are detected
- [x] Verified: indented keys under `vars:` are ignored
- [x] Verified: `seed-paths`/`snapshot-paths` are correctly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)