### PR TITLE
feat: Model Library sidebar + editing quick reference for AI agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,16 @@
         "command": "dbtSemantic.migrateToV5",
         "title": "Migrate Domains to Central Model Store",
         "category": "dbt"
+      },
+      {
+        "command": "dbtSemantic.deleteLogicalModel",
+        "title": "Delete Model",
+        "category": "dbt"
+      },
+      {
+        "command": "dbtSemantic.revealLogicalModel",
+        "title": "Reveal in Explorer",
+        "category": "dbt"
       }
     ],
     "viewsContainers": {
@@ -112,6 +122,11 @@
         {
           "id": "dbtSemantic.domainTree",
           "name": "ERD Studio"
+        },
+        {
+          "id": "dbtSemantic.modelLibrary",
+          "name": "Model Library",
+          "when": "dbtSemantic.hasLogicalModelsDir"
         }
       ]
     },
@@ -166,6 +181,10 @@
       {
         "view": "dbtSemantic.domainTree",
         "contents": "No ERD domains found.\n\nERD Studio lets you design your data warehouse visually across two stages:\n\n**Logical** — columns, data types, FK keys, and design rationale\n**Physical** — read-only view of what's built in dbt\n\n[Set Up ERD Studio](command:dbtSemantic.setupSemanticDirectory)\n\nCreates the erd-studio directory structure and your first domain.\n\n[Install AI Coding Harness](command:dbtSemantic.installCodingHarness)\n\nAdd ERD Studio schema reference to Claude, Copilot, Gemini, or Codex."
+      },
+      {
+        "view": "dbtSemantic.modelLibrary",
+        "contents": "No logical models found.\n\nModels are stored as YAML files in erd-studio/logical-models/.\n\nAdd models to a domain using the ERD editor to create them here."
       }
     ],
     "customEditors": [
@@ -201,6 +220,16 @@
           "command": "dbtSemantic.removeLayer",
           "when": "view == dbtSemantic.domainTree && viewItem == layer",
           "group": "7_modification@2"
+        },
+        {
+          "command": "dbtSemantic.revealLogicalModel",
+          "when": "view == dbtSemantic.modelLibrary && viewItem == logicalModel",
+          "group": "navigation@1"
+        },
+        {
+          "command": "dbtSemantic.deleteLogicalModel",
+          "when": "view == dbtSemantic.modelLibrary && viewItem == logicalModel",
+          "group": "7_modification@1"
         }
       ],
       "view/title": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { SchemaTagService } from './services/schemaTagService';
 import { LogicalModelService } from './services/logicalModelService';
 import { MigrationService } from './services/migrationService';
 import { YmlParserService } from './services/ymlParserService';
+import { ModelLibraryTreeProvider, type ModelLibraryNode } from './providers/ModelLibraryTreeProvider';
 
 /**
  * Find the dbt project root by searching workspace folders for dbt_project.yml.
@@ -188,6 +189,7 @@ export function activate(context: vscode.ExtensionContext): void {
     });
   }
   const treeProvider = new DomainTreeProvider(domainService, layerService, workspaceRoot, semanticDir);
+  const modelLibraryProvider = new ModelLibraryTreeProvider(logicalModelService, domainService, workspaceRoot, semanticDir);
   const editorProvider = new SemanticEditorProvider(
     context,
     domainService,
@@ -205,6 +207,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Set context key so view/title menus only show when semantic dir exists
   const fullSemanticDirPath = path.join(workspaceRoot, semanticDir);
   void vscode.commands.executeCommand('setContext', 'dbtSemantic.hasSemanticDir', fs.existsSync(fullSemanticDirPath));
+  void vscode.commands.executeCommand('setContext', 'dbtSemantic.hasLogicalModelsDir', logicalModelService.dirExists());
 
   // -------------------------------------------------------------------------
   // File watchers
@@ -254,14 +257,16 @@ export function activate(context: vscode.ExtensionContext): void {
     },
   );
 
-  // Semantic file changed externally → refresh tree view
+  // Semantic file changed externally → refresh tree view + model library
   const semanticChangedSubscription = fileWatcherService.onSemanticFileChanged(() => {
     treeProvider.refresh();
+    modelLibraryProvider.refresh();
   });
 
-  // Semantic file deleted → refresh tree and clean up orphaned domain tags
+  // Semantic file deleted → refresh tree + model library and clean up orphaned domain tags
   const semanticDeletedSubscription = fileWatcherService.onSemanticFileDeleted(async () => {
     treeProvider.refresh();
+    modelLibraryProvider.refresh();
     const result = await schemaTagService.reconcileAll();
     if (result.removed > 0) {
       void vscode.window.showInformationMessage(
@@ -270,11 +275,14 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  // Logical model file changed → refresh domains referencing that model
+  // Logical model file changed → refresh domains referencing that model + model library
   const logicalModelChangedSubscription = fileWatcherService.onLogicalModelChanged(
     async ({ modelName }) => {
       await editorProvider.refreshDomainsReferencingModel(modelName);
       treeProvider.refresh();
+      modelLibraryProvider.refresh();
+      // Re-evaluate context key so the Model Library view appears if logical-models/ was just created
+      void vscode.commands.executeCommand('setContext', 'dbtSemantic.hasLogicalModelsDir', logicalModelService.dirExists());
     },
   );
 
@@ -321,6 +329,35 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.registerCustomEditorProvider('dbtSemantic.domainEditor', editorProvider),
     vscode.window.registerFileDecorationProvider(decorationProvider),
     vscode.window.registerFileDecorationProvider(layerDecorationProvider),
+    modelLibraryProvider,
+    (() => {
+      return vscode.window.createTreeView('dbtSemantic.modelLibrary', {
+        treeDataProvider: modelLibraryProvider,
+        canSelectMany: false,
+      });
+    })(),
+    vscode.commands.registerCommand('dbtSemantic.deleteLogicalModel', async (node: ModelLibraryNode | undefined) => {
+      if (!node || node.type !== 'model') {
+        void vscode.window.showErrorMessage('Delete Model: No model selected. Right-click a model in the Model Library.');
+        return;
+      }
+      const confirm = await vscode.window.showWarningMessage(
+        `Delete model "${node.name}"? This removes the YAML file — domain references are not cleaned up.`,
+        { modal: true },
+        'Delete',
+      );
+      if (confirm === 'Delete') {
+        logicalModelService.deleteModel(node.name);
+        modelLibraryProvider.refresh();
+      }
+    }),
+    vscode.commands.registerCommand('dbtSemantic.revealLogicalModel', (node: ModelLibraryNode | undefined) => {
+      if (!node || node.type !== 'model') {
+        void vscode.window.showErrorMessage('Reveal in Explorer: No model selected. Right-click a model in the Model Library.');
+        return;
+      }
+      void vscode.commands.executeCommand('revealInExplorer', vscode.Uri.file(node.filePath));
+    }),
     vscode.commands.registerCommand('dbtSemantic.openDomain', async (filePath: string, stage?: Stage) => {
       const fileUri = vscode.Uri.file(filePath);
       await vscode.commands.executeCommand(

--- a/src/providers/ModelLibraryTreeProvider.ts
+++ b/src/providers/ModelLibraryTreeProvider.ts
@@ -1,0 +1,132 @@
+/**
+ * ModelLibraryTreeProvider — VS Code TreeDataProvider for the Model Library sidebar.
+ *
+ * Shows all model YAML files in erd-studio/logical-models/ as a flat
+ * alphabetical list. Orphaned models (not referenced by any domain) are
+ * flagged with a warning icon and "(unused)" description. Referenced models
+ * show their domain count and list domain names in the tooltip.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+import type { LogicalModelService } from '../services/logicalModelService';
+import type { DomainService } from '../services/domainService';
+import type { RawDomainFile, SemanticModel } from '../types/semantic';
+import { isDomainV5 } from '../types/semantic';
+
+// ---------------------------------------------------------------------------
+// Tree element type
+// ---------------------------------------------------------------------------
+
+export interface ModelLibraryNode {
+  readonly type: 'model';
+  readonly name: string;
+  readonly filePath: string;
+  readonly referencingDomains: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export class ModelLibraryTreeProvider implements vscode.TreeDataProvider<ModelLibraryNode> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<ModelLibraryNode | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(
+    private readonly logicalModelService: LogicalModelService,
+    private readonly domainService: DomainService,
+    private readonly projectPath: string,
+    private readonly semanticDir: string,
+  ) {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  getTreeItem(element: ModelLibraryNode): vscode.TreeItem {
+    const isOrphan = element.referencingDomains.length === 0;
+    const item = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.None);
+
+    item.contextValue = 'logicalModel';
+    item.iconPath = new vscode.ThemeIcon(isOrphan ? 'warning' : 'symbol-class');
+
+    if (isOrphan) {
+      item.description = '(unused)';
+      item.tooltip = 'Not referenced by any domain';
+    } else {
+      const count = element.referencingDomains.length;
+      item.description = `${count} ${count === 1 ? 'domain' : 'domains'}`;
+      item.tooltip = new vscode.MarkdownString(
+        `**Referenced by:**\n${element.referencingDomains.map(d => `- ${d}`).join('\n')}`,
+      );
+    }
+
+    item.resourceUri = vscode.Uri.file(element.filePath);
+    item.command = {
+      command: 'vscode.open',
+      title: 'Open Model',
+      arguments: [item.resourceUri],
+    };
+
+    return item;
+  }
+
+  getChildren(element?: ModelLibraryNode): ModelLibraryNode[] | undefined {
+    if (element) return undefined;
+
+    if (!this.logicalModelService.dirExists()) return [];
+
+    const usageMap = this.buildUsageMap();
+    return this.logicalModelService
+      .listModelNames()
+      .sort((a, b) => a.localeCompare(b))
+      .map((name): ModelLibraryNode => ({
+        type: 'model',
+        name,
+        filePath: this.logicalModelService.modelPath(name),
+        referencingDomains: usageMap.get(name) ?? [],
+      }));
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Scan all domain JSON files and build a map of model name → domain names.
+   * Uses raw JSON.parse to avoid expensive YAML model resolution.
+   */
+  private buildUsageMap(): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    const summaries = this.domainService.listDomains(this.projectPath, this.semanticDir);
+
+    for (const summary of summaries) {
+      try {
+        const raw = JSON.parse(fs.readFileSync(summary.filePath, 'utf-8')) as RawDomainFile;
+        const rawModels = raw.logical?.models ?? [];
+        const modelNames = isDomainV5(raw)
+          ? (rawModels as string[])
+          : (rawModels as SemanticModel[]).map(m => m.name);
+
+        for (const name of modelNames) {
+          const existing = map.get(name);
+          if (existing) {
+            existing.push(summary.domain);
+          } else {
+            map.set(name, [summary.domain]);
+          }
+        }
+      } catch {
+        // Skip unreadable/invalid domain files
+      }
+    }
+
+    return map;
+  }
+
+  dispose(): void {
+    this._onDidChangeTreeData.dispose();
+  }
+}

--- a/src/services/harnessService.ts
+++ b/src/services/harnessService.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 // ---------------------------------------------------------------------------
 
 /** Version of the harness content. Bump when SCHEMA_CONTENT or generators change. */
-export const HARNESS_VERSION = '10';
+export const HARNESS_VERSION = '11';
 
 const VERSION_MARKER_PREFIX = '<!-- erd-studio-harness:';
 const VERSION_MARKER_SUFFIX = ' -->';
@@ -169,6 +169,24 @@ The **Model Library** panel in the ERD Studio sidebar shows all YAML files in \`
 \`\`\`
 
 > **WARNING — Preserve existing positions:** When adding models to an existing domain file, do NOT clear or overwrite \`viewConfig.positions\`. The extension automatically computes positions for any new models that lack entries. Clearing existing positions will reset the user's carefully arranged layout.
+
+---
+
+## Editing Quick Reference
+
+**CRITICAL — Two files control the diagram.** Column data lives in the YAML; structural data lives in the JSON. You must edit the correct file for each operation.
+
+| User asks to... | Edit this file |
+|-----------------|---------------|
+| Add/remove/rename a column | \`logical-models/{name}.yml\` |
+| Change column type, PK/FK/NK flags, SCD type | \`logical-models/{name}.yml\` |
+| Change grain, modelRole, description, rationale | \`logical-models/{name}.yml\` |
+| Add a model to a domain diagram | Domain \`.json\` → add name to \`logical.models[]\` AND create \`logical-models/{name}.yml\` if it doesn't exist |
+| Remove a model from a domain | Domain \`.json\` → remove name from \`logical.models[]\` AND remove its relationships from \`logical.relationships[]\` |
+| Add/remove/edit a relationship | Domain \`.json\` → \`logical.relationships[]\` |
+| Change layout positions | Domain \`.json\` → \`viewConfig.positions\` |
+
+> **Common mistake:** Editing the \`.yml\` file alone is sufficient for column and model property changes — the extension picks up YAML changes automatically. But adding a model to the **diagram** requires BOTH creating the \`.yml\` AND adding the name string to the domain \`.json\`. Similarly, relationships are ONLY stored in the domain \`.json\`, never in the \`.yml\`.
 
 ---
 

--- a/src/services/harnessService.ts
+++ b/src/services/harnessService.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 // ---------------------------------------------------------------------------
 
 /** Version of the harness content. Bump when SCHEMA_CONTENT or generators change. */
-export const HARNESS_VERSION = '9';
+export const HARNESS_VERSION = '10';
 
 const VERSION_MARKER_PREFIX = '<!-- erd-studio-harness:';
 const VERSION_MARKER_SUFFIX = ' -->';
@@ -120,6 +120,15 @@ erd-studio/
 \`\`\`
 
 **Key principle:** Models are defined ONCE in \`logical-models/\` and referenced from multiple domain files. Editing a model from any domain updates the shared definition.
+
+### Model Library (Sidebar)
+
+The **Model Library** panel in the ERD Studio sidebar shows all YAML files in \`logical-models/\`. Use it to understand the difference between "model definition exists" and "model is referenced by a domain":
+
+- **Referenced models** show how many domains use them (e.g. "2 domains")
+- **Orphaned models** show a warning icon and "(unused)" — these exist as \`.yml\` files but are not in any domain's \`logical.models[]\` array
+
+**Important for AI agents:** Before saying a model "already exists in the ERD", check whether it is referenced by the target domain's \`logical.models[]\` array — not just whether the \`.yml\` file exists. A model file in \`logical-models/\` may be unused (orphaned) or only referenced by other domains.
 
 ## Domain File Structure
 

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -82,6 +82,14 @@ export class TreeItem {
   }
 }
 
+export class MarkdownString {
+  value: string;
+  isTrusted?: boolean;
+  constructor(value = '', supportThemeIcons?: boolean) {
+    this.value = value;
+  }
+}
+
 export class ThemeColor {
   id: string;
   constructor(id: string) {

--- a/test/unit/modelLibraryTreeProvider.test.ts
+++ b/test/unit/modelLibraryTreeProvider.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TreeItemCollapsibleState, ThemeIcon, MarkdownString } from 'vscode';
+import { ModelLibraryTreeProvider, type ModelLibraryNode } from '../../src/providers/ModelLibraryTreeProvider';
+import type { LogicalModelService } from '../../src/services/logicalModelService';
+import type { DomainService } from '../../src/services/domainService';
+import type { DomainSummary } from '../../src/types/semantic';
+
+// Mock fs — readFileSync returns domain JSON for cross-referencing
+const mockReadFileSync = vi.fn();
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function createMockLogicalModelService(
+  modelNames: string[] = [],
+  modelsDir = '/project/erd-studio/logical-models',
+): LogicalModelService {
+  return {
+    dirExists: vi.fn(() => modelNames.length > 0),
+    listModelNames: vi.fn(() => modelNames),
+    modelPath: vi.fn((name: string) => `${modelsDir}/${name}.yml`),
+    deleteModel: vi.fn(),
+  } as unknown as LogicalModelService;
+}
+
+function createMockDomainService(summaries: DomainSummary[] = []): DomainService {
+  return {
+    listDomains: vi.fn().mockReturnValue(summaries),
+  } as unknown as DomainService;
+}
+
+/** Helper to build a raw v5 domain JSON string. */
+function v5DomainJson(modelNames: string[]): string {
+  return JSON.stringify({
+    schemaVersion: 5,
+    domain: 'test',
+    layer: 'silver',
+    logical: { models: modelNames, relationships: [] },
+    viewConfig: {},
+  });
+}
+
+/** Helper to build a raw v4 domain JSON string with inline model objects. */
+function v4DomainJson(modelNames: string[]): string {
+  return JSON.stringify({
+    schemaVersion: 4,
+    domain: 'legacy',
+    layer: 'silver',
+    logical: {
+      models: modelNames.map(name => ({ name, columns: [] })),
+      relationships: [],
+    },
+    viewConfig: {},
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const SUMMARIES: DomainSummary[] = [
+  { domain: 'customer-360', layer: 'silver', filePath: '/project/erd-studio/silver/customer-360.json' },
+  { domain: 'reporting', layer: 'gold', filePath: '/project/erd-studio/gold/reporting.json' },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ModelLibraryTreeProvider', () => {
+  let provider: ModelLibraryTreeProvider;
+  let mockLogicalModelService: LogicalModelService;
+  let mockDomainService: DomainService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogicalModelService = createMockLogicalModelService(
+      ['dim_customer', 'dim_date', 'fct_orders'],
+    );
+    mockDomainService = createMockDomainService(SUMMARIES);
+
+    // Default: customer-360 references dim_customer and fct_orders,
+    // reporting references dim_customer only
+    mockReadFileSync.mockImplementation((filePath: string) => {
+      if (filePath.includes('customer-360')) {
+        return v5DomainJson(['dim_customer', 'fct_orders']);
+      }
+      if (filePath.includes('reporting')) {
+        return v5DomainJson(['dim_customer']);
+      }
+      throw new Error(`Unexpected file: ${filePath}`);
+    });
+
+    provider = new ModelLibraryTreeProvider(
+      mockLogicalModelService,
+      mockDomainService,
+      '/project',
+      'erd-studio',
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // getChildren
+  // -------------------------------------------------------------------------
+
+  describe('getChildren', () => {
+    it('returns flat list of all models sorted alphabetically', () => {
+      const children = provider.getChildren();
+      expect(children).toHaveLength(3);
+      expect(children!.map(c => c.name)).toEqual(['dim_customer', 'dim_date', 'fct_orders']);
+    });
+
+    it('returns undefined for child elements (flat list)', () => {
+      const children = provider.getChildren();
+      expect(provider.getChildren(children![0])).toBeUndefined();
+    });
+
+    it('returns empty array when logical-models dir does not exist', () => {
+      mockLogicalModelService = createMockLogicalModelService([]);
+      provider = new ModelLibraryTreeProvider(
+        mockLogicalModelService,
+        mockDomainService,
+        '/project',
+        'erd-studio',
+      );
+      expect(provider.getChildren()).toEqual([]);
+    });
+
+    it('populates referencingDomains correctly', () => {
+      const children = provider.getChildren()!;
+      const customer = children.find(c => c.name === 'dim_customer')!;
+      const date = children.find(c => c.name === 'dim_date')!;
+      const orders = children.find(c => c.name === 'fct_orders')!;
+
+      expect(customer.referencingDomains).toEqual(['customer-360', 'reporting']);
+      expect(date.referencingDomains).toEqual([]);
+      expect(orders.referencingDomains).toEqual(['customer-360']);
+    });
+
+    it('handles v4 domain files with inline model objects', () => {
+      mockReadFileSync.mockImplementation((filePath: string) => {
+        if (filePath.includes('customer-360')) {
+          return v4DomainJson(['dim_customer', 'fct_orders']);
+        }
+        if (filePath.includes('reporting')) {
+          return v4DomainJson(['dim_customer']);
+        }
+        throw new Error(`Unexpected file: ${filePath}`);
+      });
+
+      const children = provider.getChildren()!;
+      const customer = children.find(c => c.name === 'dim_customer')!;
+      expect(customer.referencingDomains).toEqual(['customer-360', 'reporting']);
+    });
+
+    it('skips unreadable domain files gracefully', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      const children = provider.getChildren()!;
+      expect(children).toHaveLength(3);
+      // All models should be orphans since no domains could be read
+      expect(children.every(c => c.referencingDomains.length === 0)).toBe(true);
+    });
+
+    it('sets correct filePath on each node', () => {
+      const children = provider.getChildren()!;
+      expect(children[0].filePath).toBe('/project/erd-studio/logical-models/dim_customer.yml');
+      expect(children[1].filePath).toBe('/project/erd-studio/logical-models/dim_date.yml');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getTreeItem
+  // -------------------------------------------------------------------------
+
+  describe('getTreeItem', () => {
+    it('renders orphan model with warning icon and (unused) description', () => {
+      const node: ModelLibraryNode = {
+        type: 'model',
+        name: 'dim_date',
+        filePath: '/project/erd-studio/logical-models/dim_date.yml',
+        referencingDomains: [],
+      };
+
+      const item = provider.getTreeItem(node);
+      expect(item.label).toBe('dim_date');
+      expect(item.description).toBe('(unused)');
+      expect(item.tooltip).toBe('Not referenced by any domain');
+      expect((item.iconPath as ThemeIcon).id).toBe('warning');
+      expect(item.collapsibleState).toBe(TreeItemCollapsibleState.None);
+      expect(item.contextValue).toBe('logicalModel');
+    });
+
+    it('renders referenced model with domain count and tooltip', () => {
+      const node: ModelLibraryNode = {
+        type: 'model',
+        name: 'dim_customer',
+        filePath: '/project/erd-studio/logical-models/dim_customer.yml',
+        referencingDomains: ['customer-360', 'reporting'],
+      };
+
+      const item = provider.getTreeItem(node);
+      expect(item.label).toBe('dim_customer');
+      expect(item.description).toBe('2 domains');
+      expect((item.iconPath as ThemeIcon).id).toBe('symbol-class');
+      expect(item.tooltip).toBeInstanceOf(MarkdownString);
+      expect((item.tooltip as MarkdownString).value).toContain('customer-360');
+      expect((item.tooltip as MarkdownString).value).toContain('reporting');
+    });
+
+    it('renders singular "domain" for single reference', () => {
+      const node: ModelLibraryNode = {
+        type: 'model',
+        name: 'fct_orders',
+        filePath: '/project/erd-studio/logical-models/fct_orders.yml',
+        referencingDomains: ['customer-360'],
+      };
+
+      const item = provider.getTreeItem(node);
+      expect(item.description).toBe('1 domain');
+    });
+
+    it('sets click command to open the .yml file', () => {
+      const node: ModelLibraryNode = {
+        type: 'model',
+        name: 'dim_customer',
+        filePath: '/project/erd-studio/logical-models/dim_customer.yml',
+        referencingDomains: [],
+      };
+
+      const item = provider.getTreeItem(node);
+      expect(item.command?.command).toBe('vscode.open');
+      expect(item.command?.arguments?.[0]?.fsPath).toContain('dim_customer.yml');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh
+  // -------------------------------------------------------------------------
+
+  describe('refresh', () => {
+    it('fires onDidChangeTreeData event', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      provider.refresh();
+      expect(listener).toHaveBeenCalledWith(undefined);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Model Library** tree view to the ERD Studio sidebar showing all `logical-models/*.yml` files with orphan detection (referenced vs unused models)
- Adds an **Editing Quick Reference** table to the AI harness that maps user requests to the correct file (`.yml` vs `.json`), preventing agents from editing only one side of the two-file architecture
- Bumps harness version to 11

## Context
Jason reported two related issues:
1. No way to see what's in `logical-models/` independently of domains — removing a model from a diagram keeps the `.yml` file, confusing AI agents into saying "model already exists"
2. AI agents editing the `.yml` but not propagating to the domain `.json` (or vice versa) — the harness didn't have a clear decision table for which file to edit

## Changes
- **New:** `src/providers/ModelLibraryTreeProvider.ts` — flat alphabetical tree with warning icons for orphans, domain count for referenced models
- **New:** `test/unit/modelLibraryTreeProvider.test.ts` — 12 unit tests covering v4/v5 domains, orphan detection, error handling
- **Modified:** `package.json` — view registration, 2 commands (Delete Model, Reveal in Explorer), context menus
- **Modified:** `src/extension.ts` — wiring, context key, watcher hooks, command guards
- **Modified:** `src/services/harnessService.ts` — editing quick reference table + Model Library docs, version 11
- **Modified:** `test/__mocks__/vscode.ts` — added `MarkdownString` class

## Test plan
- [x] `npm run compile` passes (both tsconfigs)
- [x] All 322 tests pass
- [ ] Manual: launch Extension Development Host with fixtures, verify Model Library panel appears below ERD Studio
- [ ] Manual: verify orphaned models show warning icon, referenced models show domain count
- [ ] Manual: right-click Delete Model shows confirmation dialog
- [ ] Manual: reinstall harness and verify editing quick reference appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)