### PR TITLE
fix: prevent blank screen on truncated manifest + 14x faster parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
 
       - run: npm ci
       - run: npm run compile
+      - run: npm run build
       - run: npm run test
       - run: npm run package

--- a/esbuild.js
+++ b/esbuild.js
@@ -58,6 +58,22 @@ const extensionConfig = {
   plugins: [problemMatcherPlugin],
 };
 
+// Manifest worker build — Node.js, CJS, same settings as extension host.
+// Runs JSON.parse in a worker thread for non-blocking manifest parsing.
+const workerConfig = {
+  entryPoints: ['./src/workers/manifestWorker.ts'],
+  bundle: true,
+  outfile: './dist/manifestWorker.js',
+  format: 'cjs',
+  platform: 'node',
+  target: 'node18',
+  sourcemap: !isProduction,
+  minify: isProduction,
+  treeShaking: true,
+  logLevel: 'warning',
+  plugins: [problemMatcherPlugin],
+};
+
 // Webview build — Browser, IIFE, bundle everything including React
 const webviewConfig = {
   entryPoints: ['./webview/index.tsx'],
@@ -87,16 +103,18 @@ async function build() {
   console.log(`Building [${isProduction ? 'production' : 'development'}]...`);
 
   if (isWatch) {
-    const [extCtx, webCtx] = await Promise.all([
+    const [extCtx, webCtx, workerCtx] = await Promise.all([
       esbuild.context(extensionConfig),
       esbuild.context(webviewConfig),
+      esbuild.context(workerConfig),
     ]);
-    await Promise.all([extCtx.watch(), webCtx.watch()]);
+    await Promise.all([extCtx.watch(), webCtx.watch(), workerCtx.watch()]);
     console.log('Watching for changes...');
   } else {
     await Promise.all([
       esbuild.build(extensionConfig),
       esbuild.build(webviewConfig),
+      esbuild.build(workerConfig),
     ]);
     console.log('Build complete.');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erd-studio",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erd-studio",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@vscode-elements/elements": "^1.6.0",
@@ -16,7 +16,6 @@
         "js-yaml": "^4.1.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
-        "stream-json": "^1.8.0",
         "yaml": "^2.8.2",
         "zustand": "^5.0.0"
       },
@@ -28,7 +27,6 @@
         "@types/node": "^20.17.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
-        "@types/stream-json": "^1.7.8",
         "@types/vscode": "^1.85.0",
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.4.0",
@@ -1476,27 +1474,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/stream-chain": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/stream-chain/-/stream-chain-2.1.0.tgz",
-      "integrity": "sha512-guDyAl6s/CAzXUOWpGK2bHvdiopLIwpGu8v10+lb9hnQOyo4oj/ZUQFOvqFjKGsE3wJP1fpIesCcMvbXuWsqOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/stream-json": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@types/stream-json/-/stream-json-1.7.8.tgz",
-      "integrity": "sha512-MU1OB1eFLcYWd1LjwKXrxdoPtXSRzRmAnnxs4Js/ayB5O/NvHraWwuOaqMWIebpYwM6khFlsJOHEhI9xK/ab4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/stream-chain": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -4364,21 +4341,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stream-chain": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/stream-json": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
-      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "stream-chain": "^2.2.5"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -279,7 +279,6 @@
     "@types/node": "^20.17.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@types/stream-json": "^1.7.8",
     "@types/vscode": "^1.85.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.0",
@@ -296,7 +295,6 @@
     "js-yaml": "^4.1.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "stream-json": "^1.8.0",
     "yaml": "^2.8.2",
     "zustand": "^5.0.0"
   }

--- a/src/services/manifestService.ts
+++ b/src/services/manifestService.ts
@@ -1,7 +1,7 @@
 /**
- * ManifestService — stream-parses dbt's target/manifest.json to extract model
- * and column metadata. Uses stream-json to handle ~43MB manifests without
- * blocking the extension host.
+ * ManifestService — parses dbt's target/manifest.json to extract model
+ * and column metadata. Uses JSON.parse in a worker thread for non-blocking
+ * parsing of large manifests (~14x faster than stream-json for 60MB files).
  *
  * Only the "nodes" section is extracted; macros, sources, exposures, and
  * metrics are skipped to minimise memory usage.
@@ -9,20 +9,35 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { parser } from 'stream-json';
-import { pick } from 'stream-json/filters/Pick';
-import { streamObject } from 'stream-json/streamers/StreamObject';
-import { chain } from 'stream-chain';
+import { Worker } from 'worker_threads';
 
 import type {
   ManifestColumn,
   ManifestData,
   ManifestModelInfo,
   ManifestRelationshipTest,
+  ManifestWorkerError,
+  ManifestWorkerResult,
 } from '../types/manifest';
 
-const MODEL_KEY_PREFIX = 'model.';
-const TEST_KEY_PREFIX = 'test.';
+/** Reconstruct Maps and Sets from the worker's plain-object result. */
+function deserializeWorkerResult(raw: ManifestWorkerResult): ManifestData {
+  const models = new Map(Object.entries(raw.models));
+
+  const uniqueColumns = new Map<string, Set<string>>();
+  for (const [model, cols] of Object.entries(raw.uniqueColumns)) {
+    uniqueColumns.set(model, new Set(cols));
+  }
+
+  const compositeUniqueGroups = new Map(Object.entries(raw.compositeUniqueGroups));
+
+  return {
+    models,
+    relationshipTests: raw.relationshipTests,
+    uniqueColumns,
+    compositeUniqueGroups,
+  };
+}
 
 export class ManifestService {
   private cache: ManifestData | null = null;
@@ -45,7 +60,7 @@ export class ManifestService {
   }
 
   /**
-   * Stream-parse the manifest and cache model data.
+   * Parse the manifest and cache model data.
    * Returns cached data on subsequent calls until invalidate() is called.
    *
    * If the manifest file does not exist, returns an empty ManifestData
@@ -67,6 +82,24 @@ export class ManifestService {
       const result = await this.loadPromise;
       // Only cache if we haven't been invalidated during the parse
       if (currentLoadId === this.loadId) {
+        // Semantic regression: parse succeeded but returned 0 models when
+        // we previously had data. This happens when dbt partially flushes
+        // a valid-but-incomplete JSON file (e.g. `{"metadata":{},"nodes":{}}`).
+        // Treat it like a parse failure — serve stale data and trigger retry.
+        if (
+          result.models.size === 0 &&
+          this.lastKnownGood &&
+          this.lastKnownGood.models.size > 0
+        ) {
+          console.warn(
+            '[ManifestService] Parse returned 0 models (previously had data). ' +
+            'File likely mid-write. Returning last known good data.',
+          );
+          this.cache = this.lastKnownGood;
+          this._isStale = true;
+          return this.lastKnownGood;
+        }
+
         this.cache = result;
         this.lastKnownGood = result;
         this._isStale = false;
@@ -149,7 +182,6 @@ export class ManifestService {
         continue;
       }
 
-      // Extract top-level folder: "models/silver/core/dim_customer.sql" → "models/silver"
       const parts = filePath.split('/');
       if (parts.length >= 2) {
         folders.add(`${parts[0]}/${parts[1]}`);
@@ -159,7 +191,11 @@ export class ManifestService {
     return Array.from(folders).sort();
   }
 
-  private async parseManifest(projectPath: string): Promise<ManifestData> {
+  /**
+   * Parse manifest.json in a worker thread using JSON.parse.
+   * File existence and 0-byte checks run on the main thread for fast rejection.
+   */
+  private parseManifest(projectPath: string): Promise<ManifestData> {
     const manifestPath = path.join(projectPath, 'target', 'manifest.json');
 
     if (!fs.existsSync(manifestPath)) {
@@ -167,272 +203,51 @@ export class ManifestService {
         `[ManifestService] manifest.json not found at ${manifestPath}. ` +
         'Run "dbt compile" to generate it.'
       );
-      return this.emptyManifest();
+      return Promise.resolve(this.emptyManifest());
     }
 
-    const models = new Map<string, ManifestModelInfo>();
-    const relationshipTests: ManifestRelationshipTest[] = [];
-    const uniqueColumns = new Map<string, Set<string>>();
-    const compositeUniqueGroups = new Map<string, string[][]>();
+    // Guard: file exists but is 0 bytes — dbt truncates the file before
+    // writing new content (Python open("w")), so the watcher can fire
+    // in between truncation and write. Rejecting here triggers the
+    // stale-while-revalidate fallback in loadManifest().
+    const stat = fs.statSync(manifestPath);
+    if (stat.size === 0) {
+      return Promise.reject(new Error('Manifest file is empty (likely mid-write by dbt)'));
+    }
 
     return new Promise<ManifestData>((resolve, reject) => {
-      const pipeline = chain([
-        fs.createReadStream(manifestPath, { encoding: 'utf-8' }),
-        parser(),
-        pick({ filter: 'nodes' }),
-        streamObject(),
-      ]);
+      // In production (bundled by esbuild), both extension.js and manifestWorker.js
+      // live in dist/. When running tests (vitest, unbundled), __dirname is src/services/
+      // so we resolve from the project root's dist/ directory instead.
+      const isUnbundled = __dirname.endsWith(path.join('src', 'services'));
+      const workerPath = isUnbundled
+        ? path.resolve(__dirname, '..', '..', 'dist', 'manifestWorker.js')
+        : path.join(__dirname, 'manifestWorker.js');
+      const worker = new Worker(workerPath);
 
-      pipeline.on('data', (data: { key: string; value: unknown }) => {
-        // Each entry is a key-value pair from the "nodes" object.
-        // key = manifest node key (e.g. "model.my_project.dim_work_lot")
-        // value = the full node object
-        const nodeKey = data.key;
-        const node = data.value as Record<string, unknown>;
-
-        // Extract model nodes
-        if (nodeKey.startsWith(MODEL_KEY_PREFIX)) {
-          const modelInfo = this.extractModelInfo(node);
-          if (modelInfo) {
-            models.set(modelInfo.name, modelInfo);
-          }
+      worker.once('message', (msg: ManifestWorkerResult | ManifestWorkerError) => {
+        worker.terminate();
+        if ('error' in msg) {
+          console.error(`[ManifestService] Failed to parse manifest: ${(msg as ManifestWorkerError).error}`);
+          reject(new Error(`Failed to parse manifest.json: ${(msg as ManifestWorkerError).error}`));
           return;
         }
-
-        // Extract test nodes (relationships, unique, unique_combination_of_columns)
-        if (nodeKey.startsWith(TEST_KEY_PREFIX)) {
-          const relTest = this.extractRelationshipTest(node);
-          if (relTest) {
-            relationshipTests.push(relTest);
-            return;
-          }
-
-          this.extractUniqueTest(node, uniqueColumns);
-          this.extractCompositeUniqueTest(node, compositeUniqueGroups);
-          return;
-        }
+        resolve(deserializeWorkerResult(msg as ManifestWorkerResult));
       });
 
-      pipeline.on('end', () => {
-        resolve({ models, relationshipTests, uniqueColumns, compositeUniqueGroups });
+      worker.once('error', (err) => {
+        worker.terminate();
+        reject(new Error(`Manifest worker crashed: ${err.message}`));
       });
 
-      pipeline.on('error', (err: Error) => {
-        console.error(`[ManifestService] Failed to parse manifest: ${err.message}`);
-        pipeline.destroy();
-        reject(new Error(`Failed to parse manifest.json: ${err.message}`));
+      worker.once('exit', (code) => {
+        // Fires if the worker exits without posting a message (e.g. OOM kill).
+        // If resolve/reject was already called, this is a no-op.
+        reject(new Error(`Manifest worker exited unexpectedly with code ${code}`));
       });
+
+      worker.postMessage(manifestPath);
     });
-  }
-
-  private extractModelInfo(node: Record<string, unknown>): ManifestModelInfo | null {
-    const uniqueId = node.unique_id;
-    const name = node.name;
-
-    if (typeof name !== 'string' || !name) {
-      return null;
-    }
-
-    if (typeof uniqueId !== 'string' || !uniqueId) {
-      return null;
-    }
-
-    // Extract project name from unique_id: "model.project_name.model_name"
-    const parts = uniqueId.split('.');
-    const projectName = parts.length >= 2 ? parts[1] : '';
-
-    // Extract columns from the manifest node
-    const rawColumns = node.columns;
-    const columns: ManifestColumn[] = [];
-
-    if (rawColumns && typeof rawColumns === 'object' && !Array.isArray(rawColumns)) {
-      for (const col of Object.values(rawColumns as Record<string, Record<string, unknown>>)) {
-        if (col && typeof col === 'object') {
-          columns.push({
-            name: typeof col.name === 'string' ? col.name : '',
-            data_type: typeof col.data_type === 'string' ? col.data_type : null,
-            description: typeof col.description === 'string' ? col.description : '',
-          });
-        }
-      }
-    }
-
-    return {
-      name,
-      uniqueId,
-      projectName,
-      schema: typeof node.schema === 'string' ? node.schema : '',
-      description: typeof node.description === 'string' ? node.description : '',
-      columns,
-      originalFilePath:
-        typeof node.original_file_path === 'string' ? node.original_file_path : undefined,
-    };
-  }
-
-  /**
-   * Extract relationship test info from a manifest test node.
-   *
-   * Matches any test with relationship-like kwargs structure:
-   * - Standard: test_metadata.name = 'relationships'
-   * - Custom: test_metadata.name starts with 'relationships' (e.g. 'relationships_where')
-   * - Fallback: any test with kwargs.column_name, kwargs.field, kwargs.to containing ref()
-   *
-   * kwargs structure:
-   * - kwargs.column_name = FK column in the source model
-   * - kwargs.field = PK column in the target model
-   * - kwargs.to = ref('target_model_name')
-   */
-  private extractRelationshipTest(
-    node: Record<string, unknown>,
-  ): ManifestRelationshipTest | null {
-    const testMetadata = node.test_metadata as Record<string, unknown> | undefined;
-    if (!testMetadata) {
-      return null;
-    }
-
-    const kwargs = testMetadata.kwargs as Record<string, unknown> | undefined;
-    if (!kwargs) {
-      return null;
-    }
-
-    // Extract column names — must have the relationship kwargs signature
-    const fromColumn = kwargs.column_name;
-    const toColumn = kwargs.field;
-    const toRef = kwargs.to;
-
-    if (
-      typeof fromColumn !== 'string' ||
-      typeof toColumn !== 'string' ||
-      typeof toRef !== 'string'
-    ) {
-      return null;
-    }
-
-    // Must contain a ref() call to be a relationship test
-    // Handles both ref('model') and ref('project', 'model') (cross-project)
-    const refMatch = toRef.match(/ref\(['"]([\w]+)['"]\s*\)/);
-    const twoArgRefMatch = toRef.match(/ref\(['"][^'"]+['"],\s*['"]([\w]+)['"]\s*\)/);
-    const toModel = twoArgRefMatch?.[1] ?? refMatch?.[1];
-
-    if (!toModel) {
-      return null;
-    }
-
-    // Extract fromModel from attached_node or depends_on.nodes
-    // For relationship tests, we need the model that is NOT the target
-    const attachedNode = node.attached_node as string | undefined;
-    let fromModel: string | undefined;
-
-    if (attachedNode && attachedNode.startsWith('model.')) {
-      const parts = attachedNode.split('.');
-      fromModel = parts[parts.length - 1];
-    } else {
-      // Fallback: find the first model node that is NOT the target model
-      const dependsOn = node.depends_on as { nodes?: string[] } | undefined;
-      const nodeRefs = dependsOn?.nodes ?? [];
-
-      for (const ref of nodeRefs) {
-        if (ref.startsWith('model.')) {
-          const parts = ref.split('.');
-          const modelName = parts[parts.length - 1];
-          if (modelName !== toModel) {
-            fromModel = modelName;
-            break;
-          }
-        }
-      }
-    }
-
-    if (!fromModel) {
-      return null;
-    }
-
-    return {
-      fromModel,
-      fromColumn,
-      toModel,
-      toColumn,
-    };
-  }
-
-  /**
-   * Extract a standalone `unique` test from a manifest test node.
-   *
-   * Unique tests have:
-   * - test_metadata.name = 'unique'
-   * - test_metadata.kwargs.column_name = the unique column
-   * - attached_node or depends_on.nodes to identify the model
-   */
-  private extractUniqueTest(
-    node: Record<string, unknown>,
-    uniqueColumns: Map<string, Set<string>>,
-  ): void {
-    const testMetadata = node.test_metadata as Record<string, unknown> | undefined;
-    if (!testMetadata || testMetadata.name !== 'unique') {
-      return;
-    }
-
-    const kwargs = testMetadata.kwargs as Record<string, unknown> | undefined;
-    const columnName = kwargs?.column_name;
-    if (typeof columnName !== 'string') {
-      return;
-    }
-
-    const modelName = this.resolveModelFromTestNode(node);
-    if (!modelName) {
-      return;
-    }
-
-    let columns = uniqueColumns.get(modelName);
-    if (!columns) {
-      columns = new Set<string>();
-      uniqueColumns.set(modelName, columns);
-    }
-    columns.add(columnName);
-  }
-
-  /**
-   * Extract a `unique_combination_of_columns` test from a manifest test node.
-   *
-   * These tests have:
-   * - test_metadata.name = 'unique_combination_of_columns'
-   * - test_metadata.kwargs.combination_of_columns = ['col_a', 'col_b']
-   * - attached_node or depends_on.nodes to identify the model
-   */
-  private extractCompositeUniqueTest(
-    node: Record<string, unknown>,
-    compositeUniqueGroups: Map<string, string[][]>,
-  ): void {
-    const testMetadata = node.test_metadata as Record<string, unknown> | undefined;
-    if (!testMetadata || testMetadata.name !== 'unique_combination_of_columns') {
-      return;
-    }
-
-    const kwargs = testMetadata.kwargs as Record<string, unknown> | undefined;
-    const combinationOfColumns = kwargs?.combination_of_columns;
-    if (!Array.isArray(combinationOfColumns)) {
-      return;
-    }
-
-    // Validate all entries are strings
-    const columns = combinationOfColumns.filter(
-      (c): c is string => typeof c === 'string',
-    );
-    if (columns.length === 0) {
-      return;
-    }
-
-    const modelName = this.resolveModelFromTestNode(node);
-    if (!modelName) {
-      return;
-    }
-
-    let groups = compositeUniqueGroups.get(modelName);
-    if (!groups) {
-      groups = [];
-      compositeUniqueGroups.set(modelName, groups);
-    }
-    groups.push(columns);
   }
 
   private emptyManifest(): ManifestData {
@@ -442,31 +257,5 @@ export class ManifestService {
       uniqueColumns: new Map(),
       compositeUniqueGroups: new Map(),
     };
-  }
-
-  /**
-   * Resolve the model name from a test node using attached_node (preferred)
-   * or depends_on.nodes (fallback).
-   */
-  private resolveModelFromTestNode(node: Record<string, unknown>): string | undefined {
-    // Prefer attached_node (dbt 1.0+)
-    const attachedNode = node.attached_node as string | undefined;
-    if (attachedNode && attachedNode.startsWith('model.')) {
-      const parts = attachedNode.split('.');
-      return parts[parts.length - 1];
-    }
-
-    // Fallback: first model in depends_on.nodes
-    const dependsOn = node.depends_on as { nodes?: string[] } | undefined;
-    const nodeRefs = dependsOn?.nodes ?? [];
-
-    for (const ref of nodeRefs) {
-      if (ref.startsWith('model.')) {
-        const parts = ref.split('.');
-        return parts[parts.length - 1];
-      }
-    }
-
-    return undefined;
   }
 }

--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -48,6 +48,23 @@ export interface ManifestModelInfo {
   originalFilePath?: string;
 }
 
+/**
+ * Serializable result from the manifest worker thread.
+ * Uses plain objects/arrays instead of Maps/Sets because
+ * structured clone (worker postMessage) cannot transfer them.
+ */
+export interface ManifestWorkerResult {
+  models: Record<string, ManifestModelInfo>;
+  relationshipTests: ManifestRelationshipTest[];
+  uniqueColumns: Record<string, string[]>;
+  compositeUniqueGroups: Record<string, string[][]>;
+}
+
+/** Error result from the manifest worker thread. */
+export interface ManifestWorkerError {
+  error: string;
+}
+
 /** Parsed manifest data cached in memory. */
 export interface ManifestData {
   /** Models indexed by short name (e.g. "dim_work_lot") */

--- a/src/workers/manifestExtractor.ts
+++ b/src/workers/manifestExtractor.ts
@@ -1,0 +1,253 @@
+/**
+ * Pure extraction functions for dbt manifest.json nodes.
+ *
+ * Shared between the manifest worker thread and unit tests.
+ * Returns plain objects/arrays (not Maps/Sets) so the result
+ * can be transferred via structured clone (worker postMessage).
+ */
+
+import type {
+  ManifestColumn,
+  ManifestModelInfo,
+  ManifestRelationshipTest,
+  ManifestWorkerResult,
+} from '../types/manifest';
+
+const MODEL_KEY_PREFIX = 'model.';
+const TEST_KEY_PREFIX = 'test.';
+
+/**
+ * Extract all model and test data from a parsed manifest JSON object.
+ * This is the single entry point called by the worker thread.
+ */
+export function extractManifestData(
+  manifest: Record<string, unknown>,
+): ManifestWorkerResult {
+  const nodes = manifest.nodes as Record<string, unknown> | undefined;
+  if (!nodes || typeof nodes !== 'object') {
+    return { models: {}, relationshipTests: [], uniqueColumns: {}, compositeUniqueGroups: {} };
+  }
+
+  const models: Record<string, ManifestModelInfo> = {};
+  const relationshipTests: ManifestRelationshipTest[] = [];
+  const uniqueColumns: Record<string, string[]> = {};
+  const compositeUniqueGroups: Record<string, string[][]> = {};
+
+  for (const [nodeKey, nodeValue] of Object.entries(nodes)) {
+    const node = nodeValue as Record<string, unknown>;
+
+    if (nodeKey.startsWith(MODEL_KEY_PREFIX)) {
+      const modelInfo = extractModelInfo(node);
+      if (modelInfo) {
+        models[modelInfo.name] = modelInfo;
+      }
+      continue;
+    }
+
+    if (nodeKey.startsWith(TEST_KEY_PREFIX)) {
+      const relTest = extractRelationshipTest(node);
+      if (relTest) {
+        relationshipTests.push(relTest);
+        continue;
+      }
+
+      extractUniqueTest(node, uniqueColumns);
+      extractCompositeUniqueTest(node, compositeUniqueGroups);
+    }
+  }
+
+  return { models, relationshipTests, uniqueColumns, compositeUniqueGroups };
+}
+
+function extractModelInfo(node: Record<string, unknown>): ManifestModelInfo | null {
+  const uniqueId = node.unique_id;
+  const name = node.name;
+
+  if (typeof name !== 'string' || !name) {
+    return null;
+  }
+
+  if (typeof uniqueId !== 'string' || !uniqueId) {
+    return null;
+  }
+
+  const parts = uniqueId.split('.');
+  const projectName = parts.length >= 2 ? parts[1] : '';
+
+  const rawColumns = node.columns;
+  const columns: ManifestColumn[] = [];
+
+  if (rawColumns && typeof rawColumns === 'object' && !Array.isArray(rawColumns)) {
+    for (const col of Object.values(rawColumns as Record<string, Record<string, unknown>>)) {
+      if (col && typeof col === 'object') {
+        columns.push({
+          name: typeof col.name === 'string' ? col.name : '',
+          data_type: typeof col.data_type === 'string' ? col.data_type : null,
+          description: typeof col.description === 'string' ? col.description : '',
+        });
+      }
+    }
+  }
+
+  return {
+    name,
+    uniqueId,
+    projectName,
+    schema: typeof node.schema === 'string' ? node.schema : '',
+    description: typeof node.description === 'string' ? node.description : '',
+    columns,
+    originalFilePath:
+      typeof node.original_file_path === 'string' ? node.original_file_path : undefined,
+  };
+}
+
+/**
+ * Extract relationship test info from a manifest test node.
+ *
+ * Matches any test with relationship-like kwargs structure:
+ * - Standard: test_metadata.name = 'relationships'
+ * - Custom: test_metadata.name starts with 'relationships' (e.g. 'relationships_where')
+ * - Fallback: any test with kwargs.column_name, kwargs.field, kwargs.to containing ref()
+ */
+function extractRelationshipTest(
+  node: Record<string, unknown>,
+): ManifestRelationshipTest | null {
+  const testMetadata = node.test_metadata as Record<string, unknown> | undefined;
+  if (!testMetadata) {
+    return null;
+  }
+
+  const kwargs = testMetadata.kwargs as Record<string, unknown> | undefined;
+  if (!kwargs) {
+    return null;
+  }
+
+  const fromColumn = kwargs.column_name;
+  const toColumn = kwargs.field;
+  const toRef = kwargs.to;
+
+  if (
+    typeof fromColumn !== 'string' ||
+    typeof toColumn !== 'string' ||
+    typeof toRef !== 'string'
+  ) {
+    return null;
+  }
+
+  const refMatch = toRef.match(/ref\(['"]([\w]+)['"]\s*\)/);
+  const twoArgRefMatch = toRef.match(/ref\(['"][^'"]+['"],\s*['"]([\w]+)['"]\s*\)/);
+  const toModel = twoArgRefMatch?.[1] ?? refMatch?.[1];
+
+  if (!toModel) {
+    return null;
+  }
+
+  const attachedNode = node.attached_node as string | undefined;
+  let fromModel: string | undefined;
+
+  if (attachedNode && attachedNode.startsWith('model.')) {
+    const parts = attachedNode.split('.');
+    fromModel = parts[parts.length - 1];
+  } else {
+    const dependsOn = node.depends_on as { nodes?: string[] } | undefined;
+    const nodeRefs = dependsOn?.nodes ?? [];
+
+    for (const ref of nodeRefs) {
+      if (ref.startsWith('model.')) {
+        const parts = ref.split('.');
+        const modelName = parts[parts.length - 1];
+        if (modelName !== toModel) {
+          fromModel = modelName;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!fromModel) {
+    return null;
+  }
+
+  return { fromModel, fromColumn, toModel, toColumn };
+}
+
+function extractUniqueTest(
+  node: Record<string, unknown>,
+  uniqueColumns: Record<string, string[]>,
+): void {
+  const testMetadata = node.test_metadata as Record<string, unknown> | undefined;
+  if (!testMetadata || testMetadata.name !== 'unique') {
+    return;
+  }
+
+  const kwargs = testMetadata.kwargs as Record<string, unknown> | undefined;
+  const columnName = kwargs?.column_name;
+  if (typeof columnName !== 'string') {
+    return;
+  }
+
+  const modelName = resolveModelFromTestNode(node);
+  if (!modelName) {
+    return;
+  }
+
+  if (!uniqueColumns[modelName]) {
+    uniqueColumns[modelName] = [];
+  }
+  if (!uniqueColumns[modelName].includes(columnName)) {
+    uniqueColumns[modelName].push(columnName);
+  }
+}
+
+function extractCompositeUniqueTest(
+  node: Record<string, unknown>,
+  compositeUniqueGroups: Record<string, string[][]>,
+): void {
+  const testMetadata = node.test_metadata as Record<string, unknown> | undefined;
+  if (!testMetadata || testMetadata.name !== 'unique_combination_of_columns') {
+    return;
+  }
+
+  const kwargs = testMetadata.kwargs as Record<string, unknown> | undefined;
+  const combinationOfColumns = kwargs?.combination_of_columns;
+  if (!Array.isArray(combinationOfColumns)) {
+    return;
+  }
+
+  const columns = combinationOfColumns.filter(
+    (c): c is string => typeof c === 'string',
+  );
+  if (columns.length === 0) {
+    return;
+  }
+
+  const modelName = resolveModelFromTestNode(node);
+  if (!modelName) {
+    return;
+  }
+
+  if (!compositeUniqueGroups[modelName]) {
+    compositeUniqueGroups[modelName] = [];
+  }
+  compositeUniqueGroups[modelName].push(columns);
+}
+
+function resolveModelFromTestNode(node: Record<string, unknown>): string | undefined {
+  const attachedNode = node.attached_node as string | undefined;
+  if (attachedNode && attachedNode.startsWith('model.')) {
+    const parts = attachedNode.split('.');
+    return parts[parts.length - 1];
+  }
+
+  const dependsOn = node.depends_on as { nodes?: string[] } | undefined;
+  const nodeRefs = dependsOn?.nodes ?? [];
+
+  for (const ref of nodeRefs) {
+    if (ref.startsWith('model.')) {
+      const parts = ref.split('.');
+      return parts[parts.length - 1];
+    }
+  }
+
+  return undefined;
+}

--- a/src/workers/manifestWorker.ts
+++ b/src/workers/manifestWorker.ts
@@ -1,0 +1,26 @@
+/**
+ * Worker thread for parsing dbt manifest.json.
+ *
+ * Receives a file path, reads and parses the JSON, extracts model/test data,
+ * and posts the result back to the main thread. Uses JSON.parse (V8 native)
+ * instead of stream-json for ~14x faster parsing of large manifests.
+ */
+
+import * as fs from 'fs';
+import { parentPort } from 'worker_threads';
+import { extractManifestData } from './manifestExtractor';
+import type { ManifestWorkerError } from '../types/manifest';
+
+parentPort!.once('message', (manifestPath: string) => {
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const result = extractManifestData(parsed);
+    parentPort!.postMessage(result);
+  } catch (err) {
+    const msg: ManifestWorkerError = {
+      error: err instanceof Error ? err.message : String(err),
+    };
+    parentPort!.postMessage(msg);
+  }
+});

--- a/test/fixtures/dbt-project-empty-manifest/target/manifest.json
+++ b/test/fixtures/dbt-project-empty-manifest/target/manifest.json
@@ -1,0 +1,4 @@
+{
+  "metadata": {},
+  "nodes": {}
+}

--- a/test/unit/manifestService.test.ts
+++ b/test/unit/manifestService.test.ts
@@ -16,6 +16,8 @@ const FIXTURES_DIR = path.resolve(__dirname, '../fixtures');
 const FIXTURE_PROJECT_PATH = path.resolve(FIXTURES_DIR, 'dbt-project');
 const MALFORMED_PROJECT_PATH = path.resolve(FIXTURES_DIR, 'dbt-project-malformed');
 const SPARSE_PROJECT_PATH = path.resolve(FIXTURES_DIR, 'dbt-project-sparse');
+const EMPTY_MANIFEST_PATH = path.resolve(FIXTURES_DIR, 'dbt-project-empty-manifest');
+const ZERO_BYTE_PATH = path.resolve(FIXTURES_DIR, 'dbt-project-zero-byte');
 
 describe('ManifestService', () => {
   let service: ManifestService;
@@ -378,6 +380,83 @@ describe('ManifestService', () => {
 
       expect(data.uniqueColumns.size).toBe(0);
       expect(data.compositeUniqueGroups.size).toBe(0);
+    });
+  });
+
+  describe('blank-screen defense (truncated manifest)', () => {
+    it('returns lastKnownGood when manifest is 0 bytes after having good data', async () => {
+      // First load succeeds — populates lastKnownGood
+      const goodData = await service.loadManifest(FIXTURE_PROJECT_PATH);
+      expect(goodData.models.size).toBe(4);
+
+      service.invalidate();
+
+      // 0-byte manifest triggers the stat guard → falls back to lastKnownGood
+      const fallback = await service.loadManifest(ZERO_BYTE_PATH);
+      expect(fallback.models.size).toBe(4);
+      expect(service.isStale).toBe(true);
+    });
+
+    it('returns lastKnownGood when re-parse succeeds with 0 models after having good data', async () => {
+      // First load succeeds
+      const goodData = await service.loadManifest(FIXTURE_PROJECT_PATH);
+      expect(goodData.models.size).toBe(4);
+
+      service.invalidate();
+
+      // Empty-but-valid manifest triggers the semantic regression guard
+      const fallback = await service.loadManifest(EMPTY_MANIFEST_PATH);
+      expect(fallback.models.size).toBe(4);
+      expect(service.isStale).toBe(true);
+    });
+
+    it('does not flag stale when first load returns 0 models (legitimate empty project)', async () => {
+      // No prior data — 0 models is a valid first load (user hasn't added models yet)
+      const data = await service.loadManifest(EMPTY_MANIFEST_PATH);
+      expect(data.models.size).toBe(0);
+      expect(service.isStale).toBe(false);
+    });
+
+    it('returns empty and marks stale when first load is 0 bytes (no lastKnownGood)', async () => {
+      // 0-byte file with no prior data — parse error path, no fallback available
+      const data = await service.loadManifest(ZERO_BYTE_PATH);
+      expect(data.models.size).toBe(0);
+      expect(service.isStale).toBe(true);
+    });
+
+    it('simulates full manifest-change cycle: load → invalidate → truncated file → fallback preserves data', async () => {
+      // This simulates the real-world sequence when dbt compiles:
+      // 1. Extension starts, loads good manifest
+      const goodData = await service.loadManifest(FIXTURE_PROJECT_PATH);
+      expect(goodData.models.size).toBe(4);
+      expect(goodData.relationshipTests.length).toBe(2);
+      expect(service.isStale).toBe(false);
+
+      // 2. dbt starts writing → file watcher fires → extension calls invalidate()
+      service.invalidate();
+      expect(service.isStale).toBe(false); // reset by invalidate
+
+      // 3. loadManifest is called again but manifest is 0-bytes (truncated by dbt)
+      const afterTruncation = await service.loadManifest(ZERO_BYTE_PATH);
+      // Should get the SAME good data back, not empty
+      expect(afterTruncation.models.size).toBe(4);
+      expect(afterTruncation.relationshipTests.length).toBe(2);
+      expect(service.isStale).toBe(true);
+      // Verify it's the same object reference (lastKnownGood)
+      expect(afterTruncation).toBe(goodData);
+
+      // 4. Repeat with empty-but-valid JSON ({"nodes":{}}) — second failure mode
+      service.invalidate();
+      const afterEmptyJson = await service.loadManifest(EMPTY_MANIFEST_PATH);
+      expect(afterEmptyJson.models.size).toBe(4);
+      expect(afterEmptyJson).toBe(goodData);
+      expect(service.isStale).toBe(true);
+
+      // 5. dbt finishes writing → retry fires → good manifest again
+      service.invalidate();
+      const recovered = await service.loadManifest(FIXTURE_PROJECT_PATH);
+      expect(recovered.models.size).toBe(4);
+      expect(service.isStale).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Blank-screen fix**: When dbt truncates `manifest.json` to 0 bytes before rewriting (`open("w")`), the file watcher fires mid-write. Previously this could blank the diagram with no error message. Now `ManifestService` has two defense layers: a `stat` check rejects 0-byte files, and a semantic regression check rejects parses returning 0 models when we previously had data. Both trigger the existing stale-while-revalidate fallback.
- **14x faster parsing**: Replaced `stream-json` with `JSON.parse` in a `worker_threads` Worker. For 60MB manifests: 7.6s → 556ms, with zero event loop blocking. Extraction logic moved to `src/workers/manifestExtractor.ts`, worker entry at `src/workers/manifestWorker.ts`. `stream-json` dependency removed.

## Test plan

- [ ] `npm run compile` — type-check passes
- [ ] `npm run build` — all 3 bundles produced (`extension.js`, `webview.js`, `manifestWorker.js`)
- [ ] `npm run test` — 327 tests pass (includes 5 new blank-screen defense tests + full integration cycle test)
- [ ] Open Extension Dev Host with fixture project, verify graph loads on both logical and physical stages
- [ ] Simulate truncation: `echo -n "" > test/fixtures/dbt-project/target/manifest.json && sleep 1 && git checkout test/fixtures/dbt-project/target/manifest.json` — graph should stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)