### PR TITLE
feat: add free-form canvas annotations (build notes)

### DIFF
--- a/src/providers/SemanticEditorProvider.ts
+++ b/src/providers/SemanticEditorProvider.ts
@@ -242,6 +242,7 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
           'ready', 'updatePositions', 'switchStage', 'toggleDiscrepancy',
           'refreshManifest', 'undo', 'redo', 'updateViewConfig', 'dismissWelcome',
           'viewFile', 'checkManifestStaleness', 'generateSyncPlan', 'runDbtCompile', 'launchClaudeSync',
+          'addAnnotation', 'updateAnnotation', 'removeAnnotation', 'updateAnnotationPosition',
         ]);
         if (panel?.activeStage === 'physical' && !NON_MUTATION_TYPES.has(message.type)) {
           return;
@@ -466,6 +467,38 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
             if (payload) {
               await this.queueEdit(panelKey, () =>
                 this.handleReorderColumns(document, webviewPanel.webview, payload, activeStage));
+            }
+            break;
+          }
+          case 'addAnnotation': {
+            const payload = (message as { payload?: { id: string; text: string; x: number; y: number; color?: string } }).payload;
+            if (payload) {
+              await this.queueEdit(panelKey, () =>
+                this.handleAddAnnotation(document, webviewPanel.webview, payload));
+            }
+            break;
+          }
+          case 'updateAnnotation': {
+            const payload = (message as { payload?: { id: string; text?: string; color?: string; linkedModel?: string | null; width?: number; height?: number } }).payload;
+            if (payload) {
+              await this.queueEdit(panelKey, () =>
+                this.handleUpdateAnnotation(document, webviewPanel.webview, payload));
+            }
+            break;
+          }
+          case 'removeAnnotation': {
+            const payload = (message as { payload?: { id: string } }).payload;
+            if (payload) {
+              await this.queueEdit(panelKey, () =>
+                this.handleRemoveAnnotation(document, webviewPanel.webview, payload));
+            }
+            break;
+          }
+          case 'updateAnnotationPosition': {
+            const payload = (message as { payload?: { id: string; x: number; y: number } }).payload;
+            if (payload) {
+              await this.queueEdit(panelKey, () =>
+                this.handleUpdateAnnotationPosition(document, payload));
             }
             break;
           }
@@ -1914,6 +1947,179 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[SemanticEditorProvider] Position update failed: ${message}`);
       webview.postMessage({ type: 'error', payload: { message: `Failed to save positions: ${message}` } });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Annotation handlers (build notes in viewConfig)
+  // ---------------------------------------------------------------------------
+
+  private async handleAddAnnotation(
+    document: vscode.TextDocument,
+    webview: vscode.Webview,
+    payload: { id: string; text: string; x: number; y: number; color?: string },
+  ): Promise<void> {
+    try {
+      const text = document.getText();
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const vc = (parsed.viewConfig ?? {}) as Record<string, unknown>;
+      const annotations = (vc.annotations ?? []) as Array<Record<string, unknown>>;
+      if (annotations.some((a) => a.id === payload.id)) return;
+      annotations.push({
+        id: payload.id,
+        text: payload.text,
+        x: Math.round(payload.x),
+        y: Math.round(payload.y),
+        ...(payload.color ? { color: payload.color } : {}),
+      });
+      vc.annotations = annotations;
+      parsed.viewConfig = vc;
+
+      const updatedText = JSON.stringify(parsed, null, 2) + '\n';
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(document.uri, new vscode.Range(document.positionAt(0), document.positionAt(text.length)), updatedText);
+
+      this.pendingUpdates.set(document.uri.toString(), true);
+      const success = await vscode.workspace.applyEdit(edit);
+
+      if (success) {
+        await document.save();
+        this.pendingUpdates.delete(document.uri.toString());
+        await this.sendDomainData(document, webview);
+      } else {
+        this.pendingUpdates.delete(document.uri.toString());
+        webview.postMessage({ type: 'error', payload: { message: 'Failed to add annotation.' } });
+      }
+    } catch (err) {
+      this.pendingUpdates.delete(document.uri.toString());
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[SemanticEditorProvider] Add annotation failed: ${msg}`);
+      webview.postMessage({ type: 'error', payload: { message: `Failed to add annotation: ${msg}` } });
+    }
+  }
+
+  private async handleUpdateAnnotation(
+    document: vscode.TextDocument,
+    webview: vscode.Webview,
+    payload: { id: string; text?: string; color?: string; linkedModel?: string | null; width?: number; height?: number },
+  ): Promise<void> {
+    try {
+      const text = document.getText();
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const vc = (parsed.viewConfig ?? {}) as Record<string, unknown>;
+      const annotations = (vc.annotations ?? []) as Array<Record<string, unknown>>;
+      const ann = annotations.find((a) => a.id === payload.id);
+      if (!ann) {
+        // Annotation not found — re-sync webview with current disk state
+        await this.sendDomainData(document, webview);
+        return;
+      }
+
+      if (payload.text !== undefined) ann.text = payload.text;
+      if (payload.color !== undefined) ann.color = payload.color;
+      if (payload.width !== undefined) ann.width = payload.width;
+      if (payload.height !== undefined) ann.height = payload.height;
+      if (payload.linkedModel === null) {
+        delete ann.linkedModel;
+      } else if (payload.linkedModel !== undefined) {
+        ann.linkedModel = payload.linkedModel;
+      }
+
+      parsed.viewConfig = vc;
+
+      const updatedText = JSON.stringify(parsed, null, 2) + '\n';
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(document.uri, new vscode.Range(document.positionAt(0), document.positionAt(text.length)), updatedText);
+
+      this.pendingUpdates.set(document.uri.toString(), true);
+      const success = await vscode.workspace.applyEdit(edit);
+
+      if (success) {
+        await document.save();
+        this.pendingUpdates.delete(document.uri.toString());
+        await this.sendDomainData(document, webview);
+      } else {
+        this.pendingUpdates.delete(document.uri.toString());
+        webview.postMessage({ type: 'error', payload: { message: 'Failed to update annotation.' } });
+      }
+    } catch (err) {
+      this.pendingUpdates.delete(document.uri.toString());
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[SemanticEditorProvider] Update annotation failed: ${msg}`);
+      webview.postMessage({ type: 'error', payload: { message: `Failed to update annotation: ${msg}` } });
+    }
+  }
+
+  private async handleRemoveAnnotation(
+    document: vscode.TextDocument,
+    webview: vscode.Webview,
+    payload: { id: string },
+  ): Promise<void> {
+    try {
+      const text = document.getText();
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const vc = (parsed.viewConfig ?? {}) as Record<string, unknown>;
+      const annotations = (vc.annotations ?? []) as Array<Record<string, unknown>>;
+      vc.annotations = annotations.filter((a) => a.id !== payload.id);
+      parsed.viewConfig = vc;
+
+      const updatedText = JSON.stringify(parsed, null, 2) + '\n';
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(document.uri, new vscode.Range(document.positionAt(0), document.positionAt(text.length)), updatedText);
+
+      this.pendingUpdates.set(document.uri.toString(), true);
+      const success = await vscode.workspace.applyEdit(edit);
+
+      if (success) {
+        await document.save();
+        this.pendingUpdates.delete(document.uri.toString());
+        await this.sendDomainData(document, webview);
+      } else {
+        this.pendingUpdates.delete(document.uri.toString());
+        webview.postMessage({ type: 'error', payload: { message: 'Failed to remove annotation.' } });
+      }
+    } catch (err) {
+      this.pendingUpdates.delete(document.uri.toString());
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[SemanticEditorProvider] Remove annotation failed: ${msg}`);
+      webview.postMessage({ type: 'error', payload: { message: `Failed to remove annotation: ${msg}` } });
+    }
+  }
+
+  private async handleUpdateAnnotationPosition(
+    document: vscode.TextDocument,
+    payload: { id: string; x: number; y: number },
+  ): Promise<void> {
+    try {
+      const text = document.getText();
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      const vc = (parsed.viewConfig ?? {}) as Record<string, unknown>;
+      const annotations = (vc.annotations ?? []) as Array<Record<string, unknown>>;
+      const ann = annotations.find((a) => a.id === payload.id);
+      if (!ann) return;
+
+      ann.x = Math.round(payload.x);
+      ann.y = Math.round(payload.y);
+      parsed.viewConfig = vc;
+
+      const updatedText = JSON.stringify(parsed, null, 2) + '\n';
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(document.uri, new vscode.Range(document.positionAt(0), document.positionAt(text.length)), updatedText);
+
+      this.pendingUpdates.set(document.uri.toString(), true);
+      const success = await vscode.workspace.applyEdit(edit);
+
+      if (success) {
+        await document.save();
+        this.pendingUpdates.delete(document.uri.toString());
+      } else {
+        this.pendingUpdates.delete(document.uri.toString());
+      }
+      // No sendDomainData — same as model positions, the webview already has visual state.
+    } catch (err) {
+      this.pendingUpdates.delete(document.uri.toString());
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[SemanticEditorProvider] Annotation position update failed: ${msg}`);
     }
   }
 

--- a/src/services/domainService.ts
+++ b/src/services/domainService.ts
@@ -466,6 +466,14 @@ export class DomainService {
       positions: obj.positions && typeof obj.positions === 'object' && !Array.isArray(obj.positions)
         ? (obj.positions as Record<string, { x: number; y: number }>)
         : undefined,
+      annotations: Array.isArray(obj.annotations)
+        ? (obj.annotations as unknown[]).filter(
+            (a): a is import('../types/semantic').Annotation => {
+              const r = a as Record<string, unknown>;
+              return typeof r?.id === 'string' && typeof r?.x === 'number' && typeof r?.y === 'number';
+            },
+          )
+        : undefined,
     };
   }
 }

--- a/src/services/harnessService.ts
+++ b/src/services/harnessService.ts
@@ -19,7 +19,7 @@ import * as path from 'path';
 // ---------------------------------------------------------------------------
 
 /** Version of the harness content. Bump when SCHEMA_CONTENT or generators change. */
-export const HARNESS_VERSION = '11';
+export const HARNESS_VERSION = '12';
 
 const VERSION_MARKER_PREFIX = '<!-- erd-studio-harness:';
 const VERSION_MARKER_SUFFIX = ' -->';
@@ -162,11 +162,18 @@ The **Model Library** panel in the ERD Studio sidebar shows all YAML files in \`
 | \`logical.relationships\` | Yes | Array of relationship objects |
 | \`viewConfig\` | Yes | Root-level view settings. The extension auto-assigns positions for new models |
 
-**viewConfig** must be at the root level, not inside \`logical\`. It stores node positions keyed by model name:
+**viewConfig** must be at the root level, not inside \`logical\`. It stores node positions keyed by model name, and optional canvas annotations (build notes):
 
 \`\`\`json
-"viewConfig": { "positions": { "dim_customer": { "x": 100, "y": 200 } } }
+"viewConfig": {
+  "positions": { "dim_customer": { "x": 100, "y": 200 } },
+  "annotations": [
+    { "id": "uuid", "text": "Build note text", "x": 300, "y": 50, "color": "yellow", "linkedModel": "dim_customer" }
+  ]
+}
 \`\`\`
+
+Annotations are temporary build notes — visible on the canvas while constructing models. They are view-layer data, not semantic data. Valid colours: \`yellow\`, \`blue\`, \`green\`, \`pink\`, \`orange\`. The \`linkedModel\` field is optional and draws a dashed edge to the named model.
 
 > **WARNING — Preserve existing positions:** When adding models to an existing domain file, do NOT clear or overwrite \`viewConfig.positions\`. The extension automatically computes positions for any new models that lack entries. Clearing existing positions will reset the user's carefully arranged layout.
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -14,7 +14,7 @@
 
 import type { DisplayDomain } from './display';
 import type { DiscrepancyReport } from './discrepancy';
-import type { Rationale, Cardinality, ColumnDef, DesignModel, LayoutOptions, ModelRole, Stage } from './semantic';
+import type { AnnotationColor, Rationale, Cardinality, ColumnDef, DesignModel, LayoutOptions, ModelRole, Stage } from './semantic';
 import type { GroundTruth } from './syncPlan';
 
 // ---------------------------------------------------------------------------
@@ -471,6 +471,63 @@ export interface LaunchClaudeSyncMessage {
   type: 'launchClaudeSync';
 }
 
+// ---------------------------------------------------------------------------
+// Webview → Extension: Annotation messages (build notes)
+// ---------------------------------------------------------------------------
+
+/**
+ * Request to add a new canvas annotation (post-it note).
+ */
+export interface AddAnnotationMessage {
+  type: 'addAnnotation';
+  payload: {
+    id: string;
+    text: string;
+    x: number;
+    y: number;
+    color?: AnnotationColor;
+  };
+}
+
+/**
+ * Request to update an existing annotation's content or style.
+ * Partial patch — only fields being changed need to be present.
+ */
+export interface UpdateAnnotationMessage {
+  type: 'updateAnnotation';
+  payload: {
+    id: string;
+    text?: string;
+    color?: AnnotationColor;
+    linkedModel?: string | null;
+    width?: number;
+    height?: number;
+  };
+}
+
+/**
+ * Request to remove a canvas annotation.
+ */
+export interface RemoveAnnotationMessage {
+  type: 'removeAnnotation';
+  payload: {
+    id: string;
+  };
+}
+
+/**
+ * Request to update an annotation's position (sent on drag end).
+ * Separate from updateAnnotation for high-frequency drag performance.
+ */
+export interface UpdateAnnotationPositionMessage {
+  type: 'updateAnnotationPosition';
+  payload: {
+    id: string;
+    x: number;
+    y: number;
+  };
+}
+
 /** Union of all messages the webview can send to the extension. */
 export type WebviewMessage =
   | ReadyMessage
@@ -505,7 +562,11 @@ export type WebviewMessage =
   | CheckManifestStalenessMessage
   | GenerateSyncPlanMessage
   | RunDbtCompileMessage
-  | LaunchClaudeSyncMessage;
+  | LaunchClaudeSyncMessage
+  | AddAnnotationMessage
+  | UpdateAnnotationMessage
+  | RemoveAnnotationMessage
+  | UpdateAnnotationPositionMessage;
 
 // ---------------------------------------------------------------------------
 // Utility types

--- a/src/types/semantic.ts
+++ b/src/types/semantic.ts
@@ -159,12 +159,40 @@ export interface NodePosition {
 /** ELK layout options stored as string key-value pairs. */
 export type LayoutOptions = Record<string, string>;
 
+// ---------------------------------------------------------------------------
+// Annotations (build notes)
+// ---------------------------------------------------------------------------
+
+/** Colour options for canvas annotations. */
+export type AnnotationColor = 'yellow' | 'blue' | 'green' | 'pink' | 'orange';
+
+/**
+ * A free-form canvas annotation (post-it note).
+ *
+ * Annotations are temporary build notes — visible on the canvas while
+ * constructing a model, then removed once the work is done. They live
+ * in viewConfig (view-layer data), not in logical (semantic data).
+ */
+export interface Annotation {
+  id: string;
+  text: string;
+  x: number;
+  y: number;
+  color?: AnnotationColor;
+  width?: number;
+  height?: number;
+  /** Optional link to a model — renders a dashed edge on the canvas. */
+  linkedModel?: string;
+}
+
 /** View configuration for a domain's graph editor. */
 export interface ViewConfig {
   showFkEdges?: boolean;
   layoutOptions?: LayoutOptions;
   /** Persisted node positions keyed by model name. */
   positions?: Record<string, NodePosition>;
+  /** Free-form canvas annotations (build notes). */
+  annotations?: Annotation[];
 }
 
 // ---------------------------------------------------------------------------

--- a/webview/App.tsx
+++ b/webview/App.tsx
@@ -31,6 +31,8 @@ import { useColumnExpansion, NODE_THRESHOLD } from './hooks/useColumnExpansion';
 import { useEditorStore } from './store/editorStore';
 import { ModelNode } from './components/Graph/ModelNode';
 import { FkEdge } from './components/Graph/FkEdge';
+import { AnnotationNode } from './components/Graph/AnnotationNode';
+import { AnnotationEdge } from './components/Graph/AnnotationEdge';
 import { DragLine } from './components/Graph/DragLine';
 import { Toolbar } from './components/Toolbar/Toolbar';
 import { StatusBar } from './components/Toolbar/StatusBar';
@@ -46,7 +48,7 @@ import { WelcomeModal } from './components/WelcomeModal/WelcomeModal';
 import { SyncMergeModal } from './components/SyncMergeModal/SyncMergeModal';
 import { transformDomain } from './lib/graphTransformer';
 import { stageNodeColor } from './lib/stageColors';
-import type { ModelFlowNode, FkFlowEdge } from './types/graph';
+import type { ModelFlowNode, FkFlowEdge, AnnotationFlowNode, AnnotationFlowEdge } from './types/graph';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,10 +59,10 @@ import type { ModelFlowNode, FkFlowEdge } from './types/graph';
 // ---------------------------------------------------------------------------
 
 /** Custom node types for React Flow — must be memoised or stable. */
-const nodeTypes: NodeTypes = { model: ModelNode };
+const nodeTypes: NodeTypes = { model: ModelNode, annotation: AnnotationNode };
 
 /** Custom edge types for React Flow — must be memoised or stable. */
-const edgeTypes: EdgeTypes = { fk: FkEdge };
+const edgeTypes: EdgeTypes = { fk: FkEdge, annotationLink: AnnotationEdge };
 
 function EditorCanvas() {
   const domain = useEditorStore((s) => s.domain);
@@ -97,8 +99,14 @@ function EditorCanvas() {
   const clearFkDialogEditData = useEditorStore((s) => s.clearFkDialogEditData);
   // Context menu state
   const openEdgeContextMenu = useEditorStore((s) => s.openEdgeContextMenu);
+  const openNodeContextMenu = useEditorStore((s) => s.openNodeContextMenu);
+  const openAnnotationContextMenu = useEditorStore((s) => s.openAnnotationContextMenu);
   const closeContextMenu = useEditorStore((s) => s.closeContextMenu);
   const contextMenu = useEditorStore((s) => s.contextMenu);
+  const setEditingAnnotationId = useEditorStore((s) => s.setEditingAnnotationId);
+  const annotationLinkDrag = useEditorStore((s) => s.annotationLinkDrag);
+  const updateAnnotationLinkDrag = useEditorStore((s) => s.updateAnnotationLinkDrag);
+  const endAnnotationLinkDrag = useEditorStore((s) => s.endAnnotationLinkDrag);
   // Search state (F402)
   const searchQuery = useEditorStore((s) => s.searchQuery);
   const focusSearchInput = useEditorStore((s) => s.focusSearchInput);
@@ -145,7 +153,7 @@ function EditorCanvas() {
   // State persistence (zoom, pan, selection, mode, detail panel, expansion)
   const { shouldSkipFitView, invalidSelectedNode, persistedViewport } =
     useStatePersistence();
-  const { setViewport: setReactFlowViewport } = useReactFlow();
+  const { setViewport: setReactFlowViewport, screenToFlowPosition } = useReactFlow();
 
   // Toast notification for invalid selection after restore
   const [toastMessage, setToastMessage] = useState<string | null>(null);
@@ -453,23 +461,27 @@ function EditorCanvas() {
       const connectedNodeIds = new Set<string>();
       if (currentSelectedNode) {
         connectedNodeIds.add(currentSelectedNode);
-        // Find all nodes connected to the selected node via edges
+        // Find all nodes connected to the selected node via edges (FK edges only)
         newEdges.forEach((edge) => {
-          if (edge.data) {
-            if (edge.data.fromModel === currentSelectedNode) {
-              connectedNodeIds.add(edge.data.toModel);
+          if (edge.type === 'fk' && edge.data) {
+            const fkData = edge.data as FkFlowEdge['data'];
+            if (fkData && fkData.fromModel === currentSelectedNode) {
+              connectedNodeIds.add(fkData.toModel);
             }
-            if (edge.data.toModel === currentSelectedNode) {
-              connectedNodeIds.add(edge.data.fromModel);
+            if (fkData && fkData.toModel === currentSelectedNode) {
+              connectedNodeIds.add(fkData.fromModel);
             }
           }
         });
       } else if (selectedEdge) {
         // Edge selection: only the two endpoint models stay bright
         const edge = newEdges.find((e) => e.id === selectedEdge);
-        if (edge?.data) {
-          connectedNodeIds.add(edge.data.fromModel);
-          connectedNodeIds.add(edge.data.toModel);
+        if (edge?.type === 'fk' && edge.data) {
+          const fkData = edge.data as FkFlowEdge['data'];
+          if (fkData) {
+            connectedNodeIds.add(fkData.fromModel);
+            connectedNodeIds.add(fkData.toModel);
+          }
         }
       }
 
@@ -478,7 +490,12 @@ function EditorCanvas() {
       const hasSelection = currentSelectedNode !== null || selectedEdge !== null;
       const query = searchQuery.trim() ? searchQuery.toLowerCase() : '';
       newNodes = newNodes.map((node) => {
-        const searchDimmed = query ? !node.data.modelName.toLowerCase().includes(query) : false;
+        if (node.type === 'annotation') {
+          // Annotations: not search-dimmable, not selection-dimmable
+          return node;
+        }
+        const modelData = node.data as ModelFlowNode['data'];
+        const searchDimmed = query ? !modelData.modelName.toLowerCase().includes(query) : false;
         const selectionDimmed = hasSelection && !connectedNodeIds.has(node.id);
 
         return {
@@ -495,18 +512,23 @@ function EditorCanvas() {
         };
       });
 
-      // Apply selection dimming to edges.
+      // Apply selection dimming to edges (FK edges only).
       // For node selection: an edge is bright only if both endpoints are in the connected set.
       // For edge selection: only the selected edge stays bright.
-      newEdges = newEdges.map((edge) => ({
-        ...edge,
-        data: edge.data ? {
-          ...edge.data,
-          dimmed: hasSelection && (selectedEdge
-            ? edge.id !== selectedEdge
-            : !connectedNodeIds.has(edge.data.fromModel) || !connectedNodeIds.has(edge.data.toModel)),
-        } : edge.data,
-      }));
+      newEdges = newEdges.map((edge) => {
+        if (edge.type !== 'fk' || !edge.data) return edge;
+        const fkData = edge.data as FkFlowEdge['data'];
+        if (!fkData) return edge;
+        return {
+          ...edge,
+          data: {
+            ...fkData,
+            dimmed: hasSelection && (selectedEdge
+              ? edge.id !== selectedEdge
+              : !connectedNodeIds.has(fkData.fromModel) || !connectedNodeIds.has(fkData.toModel)),
+          },
+        };
+      });
 
       // If we have a selected node, preserve the selection in the new nodes
       if (currentSelectedNode) {
@@ -555,9 +577,10 @@ function EditorCanvas() {
     [setViewport],
   );
 
-  // Handle node clicks to open the detail panel.
+  // Handle node clicks to open the detail panel (model nodes only).
   const onNodeClick = useCallback(
-    (_event: React.MouseEvent, node: ModelFlowNode) => {
+    (_event: React.MouseEvent, node: ModelFlowNode | AnnotationFlowNode) => {
+      if (node.type === 'annotation') return; // Annotations don't open detail panel
       selectNode(node.id);
       setDetailPanelOpen(true);
       setHighlightedColumns(new Set());
@@ -568,7 +591,8 @@ function EditorCanvas() {
 
   // Handle edge clicks to highlight the FK columns involved and dim unrelated nodes/edges.
   const onEdgeClick = useCallback(
-    (_event: React.MouseEvent, edge: FkFlowEdge) => {
+    (_event: React.MouseEvent, edge: FkFlowEdge | AnnotationFlowEdge) => {
+      if (edge.type !== 'fk') return; // Annotation link edges are not interactive
       if (edge.data) {
         const cols = new Set<string>();
         cols.add(`${edge.data.fromModel}:${edge.data.fromColumn}`);
@@ -640,12 +664,81 @@ function EditorCanvas() {
     };
   }, [openFkDialogWithPrefill, setToastMessage, domain?.readOnly]);
 
+  // Handle annotation drag-to-link: mouse move updates the drag line,
+  // mouse up on a model node completes the link.
+  useEffect(() => {
+    if (!annotationLinkDrag) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      updateAnnotationLinkDrag(e.clientX, e.clientY);
+    };
+
+    const handleMouseUp = (e: MouseEvent) => {
+      // Check if we dropped on a model node
+      const target = document.elementFromPoint(e.clientX, e.clientY);
+      const modelNode = target?.closest('.react-flow__node-model');
+      if (modelNode) {
+        const modelId = modelNode.getAttribute('data-id');
+        if (modelId) {
+          vscode.postMessage({
+            type: 'updateAnnotation',
+            payload: { id: annotationLinkDrag.annotationId, linkedModel: modelId },
+          });
+        }
+      }
+      endAnnotationLinkDrag();
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [annotationLinkDrag, updateAnnotationLinkDrag, endAnnotationLinkDrag, vscode]);
+
+  // Handle double-click on blank canvas to create a new annotation
+  const onPaneDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (domain?.readOnly) return;
+      // Only trigger on actual pane clicks, not double-clicks that bubbled from nodes
+      const target = event.target as HTMLElement;
+      if (!target.classList.contains('react-flow__pane')) return;
+
+      const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
+      const id = crypto.randomUUID();
+      vscode.postMessage({
+        type: 'addAnnotation',
+        payload: { id, text: '', x: Math.round(position.x), y: Math.round(position.y) },
+      });
+      setEditingAnnotationId(id);
+    },
+    [domain?.readOnly, screenToFlowPosition, vscode, setEditingAnnotationId],
+  );
+
+  // Handle right-click on nodes (model or annotation) to show context menu
+  const onNodeContextMenu = useCallback(
+    (event: React.MouseEvent, node: ModelFlowNode | AnnotationFlowNode) => {
+      event.preventDefault();
+      if (node.type === 'annotation') {
+        const annData = (node as AnnotationFlowNode).data;
+        openAnnotationContextMenu(event.clientX, event.clientY, annData.annotationId);
+      } else {
+        const modelData = (node as ModelFlowNode).data;
+        openNodeContextMenu(event.clientX, event.clientY, modelData.modelName);
+      }
+    },
+    [openAnnotationContextMenu, openNodeContextMenu],
+  );
+
   // Handle right-click on edges to show context menu (F401)
   const onEdgeContextMenu = useCallback(
-    (event: React.MouseEvent, edge: FkFlowEdge) => {
+    (event: React.MouseEvent, edge: FkFlowEdge | AnnotationFlowEdge) => {
       event.preventDefault();
-      if (edge.data) {
-        openEdgeContextMenu(event.clientX, event.clientY, edge.data);
+      if (edge.type !== 'fk') return; // Annotation link edges don't have context menu
+      const fkData = edge.data as NonNullable<FkFlowEdge['data']>;
+      if (fkData) {
+        openEdgeContextMenu(event.clientX, event.clientY, fkData);
       }
     },
     [openEdgeContextMenu],
@@ -690,12 +783,15 @@ function EditorCanvas() {
         onNodeClick={onNodeClick}
         onEdgeClick={onEdgeClick}
         onPaneClick={handlePaneClick}
+        onDoubleClick={onPaneDoubleClick}
+        onNodeContextMenu={onNodeContextMenu}
         onSelectionChange={onSelectionChange}
         onMoveEnd={onMoveEnd}
         onEdgeContextMenu={onEdgeContextMenu}
         fitView={!shouldSkipFitView}
         minZoom={0.05}
         selectionMode={SelectionMode.Partial}
+        zoomOnDoubleClick={domain.readOnly}
         nodesDraggable={domain.positionDraggable ?? !domain.readOnly}
         panOnDrag={!shiftHeld}
         selectionOnDrag={shiftHeld && !domain.readOnly}
@@ -709,6 +805,13 @@ function EditorCanvas() {
           pannable
           zoomable
           nodeColor={(node) => {
+            if (node.type === 'annotation') {
+              const colorMap: Record<string, string> = {
+                yellow: '#f59e0b', blue: '#3b82f6', green: '#22c55e',
+                pink: '#ec4899', orange: '#f97316',
+              };
+              return colorMap[(node as AnnotationFlowNode).data.color] ?? '#f59e0b';
+            }
             const d = (node as ModelFlowNode).data;
             return stageNodeColor(d.stage, d.isGhost);
           }}
@@ -723,7 +826,7 @@ function EditorCanvas() {
           nodes={nodes}
           edges={edges}
           allExpanded={allExpanded}
-          onExpandAll={() => expandAll(nodes.map((n) => n.id))}
+          onExpandAll={() => expandAll(nodes.filter((n) => n.type === 'model').map((n) => n.id))}
           onCollapseAll={collapseAll}
         />
         <StatusBar />

--- a/webview/components/ContextMenu/ContextMenu.css
+++ b/webview/components/ContextMenu/ContextMenu.css
@@ -375,3 +375,39 @@
   border: 1px solid var(--panel-border);
   color: var(--editor-fg);
 }
+
+/* ---------------------------------------------------------------------------
+   Annotation context menu
+   --------------------------------------------------------------------------- */
+
+.context-menu__color-swatches {
+  display: flex;
+  gap: 4px;
+}
+
+.context-menu__color-swatch {
+  width: 18px;
+  height: 18px;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+  padding: 0;
+}
+
+.context-menu__color-swatch:hover {
+  border-color: var(--focus-border);
+  transform: scale(1.15);
+}
+
+.context-menu__link-select {
+  flex: 1;
+  padding: 3px 6px;
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  background: var(--input-bg);
+  color: var(--input-fg);
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}

--- a/webview/components/ContextMenu/ContextMenu.tsx
+++ b/webview/components/ContextMenu/ContextMenu.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { useEditorStore } from '../../store/editorStore';
 import { useVsCodeApi } from '../../hooks/useVsCodeApi';
 import type { FkEdgeData } from '../../types/graph';
-import type { Cardinality } from '../../../src/types/semantic';
+import type { AnnotationColor, Cardinality } from '../../../src/types/semantic';
 import type { FkDialogEditData } from '../../store/editorStore';
 import { swapCardinality } from '../../lib/cardinalityUtils';
 import './ContextMenu.css';
@@ -233,6 +233,132 @@ export function ContextMenu() {
         <div className="context-menu__header">
           <span className="context-menu__title">{modelName}</span>
         </div>
+      </div>
+    );
+  }
+
+  // --- Annotation context menu ---
+  if (contextMenu.type === 'annotation') {
+    const { annotationId } = contextMenu;
+    const displayX = adjustedPosition?.x ?? contextMenu.x;
+    const displayY = adjustedPosition?.y ?? contextMenu.y;
+
+    const colorOptions: { value: AnnotationColor; label: string; swatch: string }[] = [
+      { value: 'yellow', label: 'Yellow', swatch: '#f59e0b' },
+      { value: 'blue', label: 'Blue', swatch: '#3b82f6' },
+      { value: 'green', label: 'Green', swatch: '#22c55e' },
+      { value: 'pink', label: 'Pink', swatch: '#ec4899' },
+      { value: 'orange', label: 'Orange', swatch: '#f97316' },
+    ];
+
+    // Find annotation's linked model from domain viewConfig
+    const annotation = domain?.viewConfig.annotations?.find((a) => a.id === annotationId);
+    const isLinked = !!annotation?.linkedModel;
+
+    const handleDeleteAnnotation = () => {
+      if (!confirmingDelete) {
+        setConfirmingDelete(true);
+      } else {
+        vscode.postMessage({ type: 'removeAnnotation', payload: { id: annotationId } });
+        closeContextMenu();
+      }
+    };
+
+    const handleColorChange = (color: AnnotationColor) => {
+      vscode.postMessage({ type: 'updateAnnotation', payload: { id: annotationId, color } });
+      closeContextMenu();
+    };
+
+    const handleLinkModel = (modelName: string) => {
+      vscode.postMessage({ type: 'updateAnnotation', payload: { id: annotationId, linkedModel: modelName } });
+      closeContextMenu();
+    };
+
+    const handleUnlink = () => {
+      vscode.postMessage({ type: 'updateAnnotation', payload: { id: annotationId, linkedModel: null } });
+      closeContextMenu();
+    };
+
+    return (
+      <div
+        ref={menuRef}
+        className="context-menu"
+        style={{
+          left: displayX,
+          top: displayY,
+          visibility: adjustedPosition ? 'visible' : 'hidden',
+        }}
+        role="menu"
+      >
+        <div className="context-menu__header">
+          <span className="context-menu__title">Note</span>
+          {!isReadOnly && (
+            <div className="context-menu__header-actions">
+              <button
+                className={`context-menu__delete-link${confirmingDelete ? ' context-menu__delete-link--confirming' : ''}`}
+                onClick={handleDeleteAnnotation}
+                role="menuitem"
+              >
+                {confirmingDelete ? 'Confirm?' : 'Remove'}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {!isReadOnly && (
+          <div className="context-menu__info">
+            {/* Colour picker */}
+            <div className="context-menu__row">
+              <span className="context-menu__label">Color</span>
+              <div className="context-menu__color-swatches">
+                {colorOptions.map((opt) => (
+                  <button
+                    key={opt.value}
+                    className="context-menu__color-swatch"
+                    style={{ backgroundColor: opt.swatch }}
+                    title={opt.label}
+                    onClick={() => handleColorChange(opt.value)}
+                    aria-label={`Set color to ${opt.label}`}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Link to model */}
+            {domain && domain.models.length > 0 && (
+              <div className="context-menu__row">
+                <span className="context-menu__label">Link to</span>
+                <select
+                  className="context-menu__link-select"
+                  value={annotation?.linkedModel ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (val) handleLinkModel(val);
+                    else handleUnlink();
+                  }}
+                >
+                  <option value="">None</option>
+                  {domain.models.map((m) => (
+                    <option key={m.name} value={m.name}>{m.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {/* Unlink shortcut when linked */}
+            {isLinked && (
+              <div className="context-menu__row">
+                <button
+                  className="context-menu__edit-link"
+                  onClick={handleUnlink}
+                  role="menuitem"
+                >
+                  Unlink from {annotation?.linkedModel}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/webview/components/Graph/AnnotationEdge.tsx
+++ b/webview/components/Graph/AnnotationEdge.tsx
@@ -1,0 +1,42 @@
+/**
+ * AnnotationEdge — dashed edge linking an annotation to a model.
+ *
+ * Purely visual — no interactivity, no labels, no arrows.
+ * Uses a bezier path with a dashed stroke.
+ */
+
+import { memo } from 'react';
+import { getBezierPath, type EdgeProps } from '@xyflow/react';
+import type { AnnotationFlowEdge } from '../../types/graph';
+
+function AnnotationEdgeInner({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+}: EdgeProps<AnnotationFlowEdge>) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return (
+    <path
+      d={edgePath}
+      fill="none"
+      stroke="var(--vscode-descriptionForeground, #999)"
+      strokeWidth={1.5}
+      strokeDasharray="6 4"
+      strokeOpacity={0.5}
+      className="annotation-edge"
+    />
+  );
+}
+
+export const AnnotationEdge = memo(AnnotationEdgeInner);

--- a/webview/components/Graph/AnnotationNode.css
+++ b/webview/components/Graph/AnnotationNode.css
@@ -1,0 +1,282 @@
+/* ---------------------------------------------------------------------------
+   AnnotationNode — canvas build note (post-it note) styling
+   --------------------------------------------------------------------------- */
+
+.annotation-node {
+  min-width: 160px;
+  min-height: 80px;
+  max-width: 320px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: grab;
+  border-left: 4px solid transparent;
+  position: relative;
+}
+
+/* --- Colour variants (opaque backgrounds) -------------------------------- */
+
+.annotation-node--yellow {
+  background: #fef3c7;
+  border-left-color: #f59e0b;
+  color: #78350f;
+}
+
+.annotation-node--blue {
+  background: #dbeafe;
+  border-left-color: #3b82f6;
+  color: #1e3a5f;
+}
+
+.annotation-node--green {
+  background: #dcfce7;
+  border-left-color: #22c55e;
+  color: #14532d;
+}
+
+.annotation-node--pink {
+  background: #fce7f3;
+  border-left-color: #ec4899;
+  color: #831843;
+}
+
+.annotation-node--orange {
+  background: #fed7aa;
+  border-left-color: #f97316;
+  color: #7c2d12;
+}
+
+/* Dark themes — opaque dark backgrounds instead of translucent */
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node--yellow,
+body[data-vscode-theme-kind="vscode-high-contrast"] .annotation-node--yellow {
+  background: #422006;
+  color: #fcd34d;
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node--blue,
+body[data-vscode-theme-kind="vscode-high-contrast"] .annotation-node--blue {
+  background: #172554;
+  color: #93c5fd;
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node--green,
+body[data-vscode-theme-kind="vscode-high-contrast"] .annotation-node--green {
+  background: #052e16;
+  color: #86efac;
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node--pink,
+body[data-vscode-theme-kind="vscode-high-contrast"] .annotation-node--pink {
+  background: #500724;
+  color: #f9a8d4;
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node--orange,
+body[data-vscode-theme-kind="vscode-high-contrast"] .annotation-node--orange {
+  background: #431407;
+  color: #fdba74;
+}
+
+/* Read-only state */
+.annotation-node--readonly {
+  opacity: 0.85;
+  cursor: default;
+}
+
+/* --- Text display -------------------------------------------------------- */
+
+.annotation-node__text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  user-select: none;
+}
+
+.annotation-node__placeholder {
+  opacity: 0.5;
+  font-style: italic;
+}
+
+/* Textarea for editing */
+.annotation-node__textarea {
+  width: 100%;
+  min-height: 60px;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: vertical;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+/* --- Inline toolbar (top-right corner) ----------------------------------- */
+
+.annotation-node__toolbar {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Drag-to-link handle (chain icon) */
+.annotation-node__link-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  font-size: 12px;
+  cursor: grab;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.1s ease;
+  user-select: none;
+}
+
+.annotation-node:hover .annotation-node__link-handle {
+  opacity: 0.5;
+}
+
+.annotation-node__link-handle:hover {
+  opacity: 1 !important;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node__link-handle:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.annotation-node__toolbar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.1s ease;
+  letter-spacing: 1px;
+}
+
+.annotation-node:hover .annotation-node__toolbar-toggle {
+  opacity: 0.6;
+}
+
+.annotation-node__toolbar-toggle:hover {
+  opacity: 1 !important;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node__toolbar-toggle:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.annotation-node__toolbar-panel {
+  position: absolute;
+  top: 24px;
+  right: 0;
+  min-width: 150px;
+  background: var(--panel-bg, #252526);
+  border: 1px solid var(--panel-border, #404040);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Colour swatches */
+.annotation-node__color-row {
+  display: flex;
+  gap: 4px;
+  padding: 2px 0;
+}
+
+.annotation-node__color-swatch {
+  width: 18px;
+  height: 18px;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+}
+
+.annotation-node__color-swatch:hover {
+  transform: scale(1.15);
+}
+
+.annotation-node__color-swatch--active {
+  border-color: var(--editor-fg, #d4d4d4);
+}
+
+/* Link to model */
+.annotation-node__link-row {
+  padding: 2px 0;
+}
+
+.annotation-node__link-select {
+  width: 100%;
+  padding: 3px 6px;
+  border: 1px solid var(--panel-border, #404040);
+  border-radius: 4px;
+  background: var(--input-bg, #3c3c3c);
+  color: var(--input-fg, #cccccc);
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+/* Delete button */
+.annotation-node__delete-btn {
+  width: 100%;
+  padding: 4px 6px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--error-fg, #f48771);
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease;
+}
+
+.annotation-node__delete-btn:hover {
+  background: rgba(239, 68, 68, 0.15);
+}
+
+/* --- Linked model badge -------------------------------------------------- */
+
+.annotation-node__link-badge {
+  margin-top: 6px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  opacity: 0.7;
+  background: rgba(0, 0, 0, 0.08);
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .annotation-node__link-badge,
+body[data-vscode-theme-kind="vscode-high-contrast"] .annotation-node__link-badge {
+  background: rgba(255, 255, 255, 0.1);
+}

--- a/webview/components/Graph/AnnotationNode.tsx
+++ b/webview/components/Graph/AnnotationNode.tsx
@@ -1,0 +1,269 @@
+/**
+ * AnnotationNode — custom React Flow node for canvas build notes (post-it notes).
+ *
+ * Renders a coloured sticky note with inline text editing. Annotations are
+ * temporary build notes — visible while constructing a model, then removed
+ * once the work is done.
+ *
+ * Features:
+ * - Inline toolbar (ellipsis button) with colour picker, link dropdown, delete
+ * - Drag handle to link the note to a model (drag the chain icon to a model node)
+ * - Handles on all 4 sides for closest-side edge routing
+ */
+
+import { memo, useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import type { AnnotationFlowNode } from '../../types/graph';
+import type { AnnotationColor } from '../../../src/types/semantic';
+import { useEditorStore } from '../../store/editorStore';
+import { useVsCodeApi } from '../../hooks/useVsCodeApi';
+import './AnnotationNode.css';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Invisible handles for edge routing (same pattern as ModelNode). */
+const HANDLE_STYLE: CSSProperties = {
+  width: 1,
+  height: 1,
+  minWidth: 0,
+  minHeight: 0,
+  opacity: 0,
+  pointerEvents: 'none',
+};
+
+const COLOR_OPTIONS: { value: AnnotationColor; swatch: string }[] = [
+  { value: 'yellow', swatch: '#f59e0b' },
+  { value: 'blue', swatch: '#3b82f6' },
+  { value: 'green', swatch: '#22c55e' },
+  { value: 'pink', swatch: '#ec4899' },
+  { value: 'orange', swatch: '#f97316' },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+function AnnotationNodeInner({ data }: NodeProps<AnnotationFlowNode>) {
+  const vscode = useVsCodeApi();
+  const editingAnnotationId = useEditorStore((s) => s.editingAnnotationId);
+  const setEditingAnnotationId = useEditorStore((s) => s.setEditingAnnotationId);
+  const domain = useEditorStore((s) => s.domain);
+  const startAnnotationLinkDrag = useEditorStore((s) => s.startAnnotationLinkDrag);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const toolbarPanelRef = useRef<HTMLDivElement>(null);
+  const toolbarToggleRef = useRef<HTMLButtonElement>(null);
+  const [localText, setLocalText] = useState(data.text);
+  const [toolbarOpen, setToolbarOpen] = useState(false);
+  const isEditing = editingAnnotationId === data.annotationId;
+
+  // Sync local text when data changes from extension
+  useEffect(() => {
+    if (!isEditing) {
+      setLocalText(data.text);
+    }
+  }, [data.text, isEditing]);
+
+  // Auto-focus when this annotation enters editing mode
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, [isEditing]);
+
+  // Close toolbar on click outside (capture phase to beat React Flow's event handling)
+  useEffect(() => {
+    if (!toolbarOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        toolbarPanelRef.current && !toolbarPanelRef.current.contains(e.target as Node) &&
+        toolbarToggleRef.current && !toolbarToggleRef.current.contains(e.target as Node)
+      ) {
+        setToolbarOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handleClickOutside, true);
+    return () => window.removeEventListener('mousedown', handleClickOutside, true);
+  }, [toolbarOpen]);
+
+  const commitText = useCallback(() => {
+    setEditingAnnotationId(null);
+    if (localText !== data.text) {
+      vscode.postMessage({
+        type: 'updateAnnotation',
+        payload: { id: data.annotationId, text: localText },
+      });
+    }
+  }, [localText, data.text, data.annotationId, vscode, setEditingAnnotationId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        commitText();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setLocalText(data.text);
+        setEditingAnnotationId(null);
+      }
+      // Stop propagation so React Flow doesn't handle keys while editing
+      e.stopPropagation();
+    },
+    [commitText, data.text, setEditingAnnotationId],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!data.readOnly) {
+        setEditingAnnotationId(data.annotationId);
+      }
+    },
+    [data.readOnly, data.annotationId, setEditingAnnotationId],
+  );
+
+  const handleColorChange = useCallback(
+    (color: AnnotationColor) => {
+      vscode.postMessage({ type: 'updateAnnotation', payload: { id: data.annotationId, color } });
+      setToolbarOpen(false);
+    },
+    [data.annotationId, vscode],
+  );
+
+  const handleLinkChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      e.stopPropagation();
+      const val = e.target.value;
+      vscode.postMessage({
+        type: 'updateAnnotation',
+        payload: { id: data.annotationId, linkedModel: val || null },
+      });
+    },
+    [data.annotationId, vscode],
+  );
+
+  const handleDelete = useCallback(() => {
+    vscode.postMessage({ type: 'removeAnnotation', payload: { id: data.annotationId } });
+    setToolbarOpen(false);
+  }, [data.annotationId, vscode]);
+
+  // Drag-to-link: start drag from the link handle
+  const handleLinkDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      startAnnotationLinkDrag(data.annotationId, e.clientX, e.clientY);
+    },
+    [data.annotationId, startAnnotationLinkDrag],
+  );
+
+  const colorClass = `annotation-node--${data.color}`;
+  const style: React.CSSProperties = {};
+  if (data.width) style.width = data.width;
+  if (data.height) style.height = data.height;
+
+  const modelNames = domain?.models.map((m) => m.name) ?? [];
+
+  return (
+    <div
+      className={`annotation-node ${colorClass}${data.readOnly ? ' annotation-node--readonly' : ''}`}
+      style={style}
+      onDoubleClick={handleDoubleClick}
+    >
+      {/* Inline toolbar — visible on hover */}
+      {!data.readOnly && (
+        <div className="annotation-node__toolbar">
+          {/* Drag-to-link handle */}
+          <div
+            className="annotation-node__link-handle nodrag"
+            onMouseDown={handleLinkDragStart}
+            title="Drag to a model to link"
+          >
+            &#x1F517;
+          </div>
+          <button
+            ref={toolbarToggleRef}
+            className="annotation-node__toolbar-toggle"
+            onClick={(e) => { e.stopPropagation(); setToolbarOpen(!toolbarOpen); }}
+            title="Note options"
+          >
+            &#x22EF;
+          </button>
+          {toolbarOpen && (
+            <div ref={toolbarPanelRef} className="annotation-node__toolbar-panel nodrag nowheel" onClick={(e) => e.stopPropagation()}>
+              {/* Colour swatches */}
+              <div className="annotation-node__color-row">
+                {COLOR_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    className={`annotation-node__color-swatch${data.color === opt.value ? ' annotation-node__color-swatch--active' : ''}`}
+                    style={{ backgroundColor: opt.swatch }}
+                    onClick={() => handleColorChange(opt.value)}
+                    title={opt.value}
+                  />
+                ))}
+              </div>
+              {/* Link to model (fallback dropdown) */}
+              <div className="annotation-node__link-row">
+                <select
+                  className="annotation-node__link-select nodrag"
+                  value={data.linkedModel ?? ''}
+                  onChange={handleLinkChange}
+                >
+                  <option value="">No link</option>
+                  {modelNames.map((name) => (
+                    <option key={name} value={name}>{name}</option>
+                  ))}
+                </select>
+              </div>
+              {/* Delete */}
+              <button className="annotation-node__delete-btn" onClick={handleDelete}>
+                Remove note
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Text area — nodrag prevents React Flow drag when interacting with textarea/resize */}
+      {isEditing && !data.readOnly ? (
+        <textarea
+          ref={textareaRef}
+          className="annotation-node__textarea nodrag nowheel"
+          value={localText}
+          onChange={(e) => setLocalText(e.target.value)}
+          onBlur={commitText}
+          onKeyDown={handleKeyDown}
+          placeholder="Type a build note..."
+        />
+      ) : (
+        <div className="annotation-node__text">
+          {data.text || (
+            <span className="annotation-node__placeholder">
+              Double-click to edit...
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Linked model badge */}
+      {data.linkedModel && (
+        <div className="annotation-node__link-badge" title={`Linked to ${data.linkedModel}`}>
+          &#x1F517; {data.linkedModel}
+        </div>
+      )}
+
+      {/* Invisible handles on all 4 sides for closest-side edge routing */}
+      <Handle type="source" position={Position.Top} id="node-top-src" style={HANDLE_STYLE} />
+      <Handle type="source" position={Position.Right} id="node-right-src" style={HANDLE_STYLE} />
+      <Handle type="source" position={Position.Bottom} id="node-bottom-src" style={HANDLE_STYLE} />
+      <Handle type="source" position={Position.Left} id="node-left-src" style={HANDLE_STYLE} />
+    </div>
+  );
+}
+
+export const AnnotationNode = memo(AnnotationNodeInner);

--- a/webview/components/Graph/DragLine.css
+++ b/webview/components/Graph/DragLine.css
@@ -17,3 +17,11 @@
   fill: none;
   opacity: 0.9;
 }
+
+.drag-line__path--annotation {
+  stroke: var(--vscode-descriptionForeground, #999);
+  stroke-width: 1.5;
+  stroke-dasharray: 6, 4;
+  opacity: 0.7;
+  pointer-events: none;
+}

--- a/webview/components/Graph/DragLine.tsx
+++ b/webview/components/Graph/DragLine.tsx
@@ -1,9 +1,11 @@
 /**
- * DragLine — visual feedback for column drag-to-connect relationships.
+ * DragLine — visual feedback for drag-to-connect operations.
  *
- * Renders a dashed orange line from the source column to the current cursor
- * position while dragging. Uses design edge styling to indicate this will
- * create a design relationship.
+ * Renders either:
+ * - A dashed orange line for column drag-to-connect (FK relationship creation)
+ * - A dashed grey line for annotation drag-to-link (annotation linking)
+ *
+ * Both use fixed-position SVG overlays that follow the cursor.
  */
 
 import { useEditorStore } from '../../store/editorStore';
@@ -11,10 +13,9 @@ import './DragLine.css';
 
 export function DragLine() {
   const dragLineState = useEditorStore((s) => s.dragLineState);
+  const annotationLinkDrag = useEditorStore((s) => s.annotationLinkDrag);
 
-  if (!dragLineState) return null;
-
-  const { sourceX, sourceY, currentX, currentY } = dragLineState;
+  if (!dragLineState && !annotationLinkDrag) return null;
 
   return (
     <svg
@@ -42,14 +43,29 @@ export function DragLine() {
           <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--edge-design)" />
         </marker>
       </defs>
-      <line
-        x1={sourceX}
-        y1={sourceY}
-        x2={currentX}
-        y2={currentY}
-        className="drag-line__path"
-        markerEnd="url(#drag-line-arrow)"
-      />
+
+      {/* FK column drag line */}
+      {dragLineState && (
+        <line
+          x1={dragLineState.sourceX}
+          y1={dragLineState.sourceY}
+          x2={dragLineState.currentX}
+          y2={dragLineState.currentY}
+          className="drag-line__path"
+          markerEnd="url(#drag-line-arrow)"
+        />
+      )}
+
+      {/* Annotation link drag line */}
+      {annotationLinkDrag && (
+        <line
+          x1={annotationLinkDrag.sourceX}
+          y1={annotationLinkDrag.sourceY}
+          x2={annotationLinkDrag.currentX}
+          y2={annotationLinkDrag.currentY}
+          className="drag-line__path drag-line__path--annotation"
+        />
+      )}
     </svg>
   );
 }

--- a/webview/components/Legend/Legend.css
+++ b/webview/components/Legend/Legend.css
@@ -227,6 +227,30 @@
   stroke: var(--stage-physical);
 }
 
+.legend__edge--annotation {
+  stroke: var(--vscode-descriptionForeground, #999);
+  stroke-dasharray: 6 4;
+  stroke-opacity: 0.5;
+}
+
+/* ---------------------------------------------------------------------------
+   Annotation card sample
+   --------------------------------------------------------------------------- */
+
+.legend__annotation-card {
+  width: 36px;
+  height: 24px;
+  border-radius: 3px;
+  border-left: 3px solid #f59e0b;
+  background: #fef3c7;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+body[data-vscode-theme-kind="vscode-dark"] .legend__annotation-card,
+body[data-vscode-theme-kind="vscode-high-contrast"] .legend__annotation-card {
+  background: #422006;
+}
+
 /* ---------------------------------------------------------------------------
    Cardinality display
    --------------------------------------------------------------------------- */

--- a/webview/components/Legend/Legend.tsx
+++ b/webview/components/Legend/Legend.tsx
@@ -93,6 +93,26 @@ export function Legend() {
           </div>
         </section>
 
+        {/* Annotations Section */}
+        <section className="legend__section">
+          <h3 className="legend__section-title">Annotations</h3>
+          <div className="legend__items">
+            <div className="legend__item">
+              <div className="legend__annotation-card" />
+              <div className="legend__item-text">
+                <span className="legend__item-label">Build Note</span>
+                <span className="legend__item-desc">Temporary note on canvas</span>
+              </div>
+            </div>
+            <div className="legend__item">
+              <svg className="legend__edge-sample" viewBox="0 0 48 8" aria-hidden="true">
+                <line x1="0" y1="4" x2="48" y2="4" className="legend__edge legend__edge--annotation" />
+              </svg>
+              <span className="legend__item-desc">Note linked to model</span>
+            </div>
+          </div>
+        </section>
+
         {/* Cardinality Section */}
         <section className="legend__section">
           <h3 className="legend__section-title">Cardinality</h3>

--- a/webview/components/Toolbar/Toolbar.css
+++ b/webview/components/Toolbar/Toolbar.css
@@ -259,6 +259,12 @@
   border-bottom: 1px solid var(--panel-border);
 }
 
+.toolbar__dropdown-divider {
+  height: 1px;
+  background: var(--panel-border);
+  margin: 0;
+}
+
 /* ---------------------------------------------------------------------------
    Search (F402)
    --------------------------------------------------------------------------- */

--- a/webview/components/Toolbar/Toolbar.tsx
+++ b/webview/components/Toolbar/Toolbar.tsx
@@ -28,7 +28,7 @@ import {
   type LayoutDirection,
 } from '../../lib/elkLayout';
 import { StageTabs } from './StageTabs';
-import type { ModelFlowNode, FkFlowEdge } from '../../types/graph';
+import type { ModelFlowNode, FkFlowEdge, AnnotationFlowNode, AnnotationFlowEdge } from '../../types/graph';
 import type { Stage } from '../../../src/types/semantic';
 import type { WebviewMessage } from '../../hooks/useMessageBus';
 import './Toolbar.css';
@@ -49,8 +49,8 @@ const LAYER_ABBREV_FALLBACK: Record<string, string> = {
 // ---------------------------------------------------------------------------
 
 interface ToolbarProps {
-  nodes: ModelFlowNode[];
-  edges: FkFlowEdge[];
+  nodes: (ModelFlowNode | AnnotationFlowNode)[];
+  edges: (FkFlowEdge | AnnotationFlowEdge)[];
   /** Whether all columns are currently expanded. */
   allExpanded: boolean;
   /** Expand all columns in all nodes. */
@@ -65,7 +65,8 @@ interface ToolbarProps {
 
 export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll }: ToolbarProps) {
   const vscode = useVsCodeApi();
-  const { zoomIn, zoomOut, fitView, getNode } = useReactFlow();
+  const reactFlowInstance = useReactFlow();
+  const { zoomIn, zoomOut, fitView, getNode } = reactFlowInstance;
   const domain = useEditorStore((s) => s.domain);
   const setDomain = useEditorStore((s) => s.setDomain);
   const setNewModelDialogOpen = useEditorStore((s) => s.setNewModelDialogOpen);
@@ -114,7 +115,7 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
     if (!searchQuery.trim()) return [];
     const query = searchQuery.toLowerCase();
     return nodes
-      .filter((node) => node.data.modelName.toLowerCase().includes(query))
+      .filter((node) => node.type === 'model' && (node.data as ModelFlowNode['data']).modelName.toLowerCase().includes(query))
       .map((node) => node.id);
   }, [searchQuery, nodes]);
 
@@ -276,6 +277,21 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
     setNewFkDialogOpen(true);
   }, [setNewFkDialogOpen]);
 
+  const setEditingAnnotationId = useEditorStore((s) => s.setEditingAnnotationId);
+  const handleNewAnnotation = useCallback(() => {
+    setModelDropdownOpen(false);
+    // Place annotation near the center of the viewport
+    const { x, y, zoom } = reactFlowInstance.getViewport();
+    const viewportCenterX = (-x + window.innerWidth / 2) / zoom;
+    const viewportCenterY = (-y + window.innerHeight / 2) / zoom;
+    const id = crypto.randomUUID();
+    vscode.postMessage({
+      type: 'addAnnotation',
+      payload: { id, text: '', x: Math.round(viewportCenterX), y: Math.round(viewportCenterY) },
+    });
+    setEditingAnnotationId(id);
+  }, [vscode, setEditingAnnotationId]);
+
   // --- Auto Layout handlers ------------------------------------------------
 
   const runLayout = useCallback(async () => {
@@ -290,9 +306,12 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
       const effectiveBound = partitionStrategy === 'auto'
         ? detectLayerBound(nodes.length)
         : layerBound;
+      // Filter to model nodes/FK edges only — annotations are exempt from auto-layout.
+      const modelNodes = nodes.filter((n): n is import('../../types/graph').ModelFlowNode => n.type === 'model');
+      const fkEdges = edges.filter((e): e is import('../../types/graph').FkFlowEdge => e.type === 'fk');
       const positions = await runElkLayout(
-        nodes,
-        edges,
+        modelNodes,
+        fkEdges,
         {
           ...domain.viewConfig.layoutOptions,
           'elk.direction': layoutDirection,
@@ -511,7 +530,9 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
                 <div className="toolbar__lp-section">
                   <span className="toolbar__lp-label">Grouping</span>
                   {(() => {
-                    const resolved = partitionStrategy === 'auto' ? detectStrategy(nodes, edges) : null;
+                    const modelOnly = nodes.filter((n): n is ModelFlowNode => n.type === 'model');
+                    const fkOnly = edges.filter((e): e is FkFlowEdge => e.type === 'fk');
+                    const resolved = partitionStrategy === 'auto' ? detectStrategy(modelOnly, fkOnly) : null;
                     return (
                       <div className="toolbar__lp-track">
                         {([
@@ -537,7 +558,7 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
                   })()}
                   <span className="toolbar__lp-desc">
                     {partitionStrategy === 'auto' ? (() => {
-                      const r = detectStrategy(nodes, edges);
+                      const r = detectStrategy(nodes.filter((n): n is ModelFlowNode => n.type === 'model'), edges.filter((e): e is FkFlowEdge => e.type === 'fk'));
                       return r === 'role'
                         ? 'Using Model type — your models have roles assigned.'
                         : r === 'depth'
@@ -753,6 +774,14 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
                       role="menuitem"
                     >
                       New Relationship
+                    </button>
+                    <div className="toolbar__dropdown-divider" />
+                    <button
+                      className="toolbar__dropdown-item"
+                      onClick={handleNewAnnotation}
+                      role="menuitem"
+                    >
+                      New Note
                     </button>
                   </div>
                 )}

--- a/webview/hooks/usePositionPersistence.ts
+++ b/webview/hooks/usePositionPersistence.ts
@@ -20,7 +20,7 @@ import {
 import { useVsCodeApi } from './useVsCodeApi';
 import { useEditorStore } from '../store/editorStore';
 import type { WebviewMessage } from './useMessageBus';
-import type { ModelFlowNode } from '../types/graph';
+import type { ModelFlowNode, AnnotationFlowNode } from '../types/graph';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -76,23 +76,48 @@ export function usePositionPersistence(): {
       // Flush pending changes to extension host.
       if (pendingChangesRef.current.size > 0 && domainRef.current) {
         const latestDomain = domainRef.current;
-        const changedPositions = Object.fromEntries(pendingChangesRef.current);
 
-        // Send only the delta — extension merges over disk positions to avoid
-        // concurrent tabs clobbering each other's saves.
-        const message: WebviewMessage = {
-          type: 'updatePositions',
-          payload: { positions: changedPositions },
-        };
-        vscode.postMessage(message);
+        // Partition: annotation nodes vs model nodes.
+        const modelPositions: Record<string, { x: number; y: number }> = {};
+        const annotationPositions: Array<{ id: string; x: number; y: number }> = [];
+
+        for (const [nodeId, pos] of pendingChangesRef.current) {
+          if (nodeId.startsWith('annotation-')) {
+            annotationPositions.push({ id: nodeId.slice('annotation-'.length), x: pos.x, y: pos.y });
+          } else {
+            modelPositions[nodeId] = pos;
+          }
+        }
+
+        if (Object.keys(modelPositions).length > 0) {
+          const message: WebviewMessage = {
+            type: 'updatePositions',
+            payload: { positions: modelPositions },
+          };
+          vscode.postMessage(message);
+        }
+
+        for (const ann of annotationPositions) {
+          vscode.postMessage({
+            type: 'updateAnnotationPosition',
+            payload: ann,
+          } as WebviewMessage);
+        }
 
         // Optimistic local update with full merge for correct UI rendering
         const existingPositions = latestDomain.viewConfig.positions ?? {};
+        const updatedAnnotations = annotationPositions.length > 0 && latestDomain.viewConfig.annotations
+          ? latestDomain.viewConfig.annotations.map((ann) => {
+              const moved = annotationPositions.find((a) => a.id === ann.id);
+              return moved ? { ...ann, x: moved.x, y: moved.y } : ann;
+            })
+          : latestDomain.viewConfig.annotations;
         setDomain({
           ...latestDomain,
           viewConfig: {
             ...latestDomain.viewConfig,
-            positions: { ...existingPositions, ...changedPositions },
+            positions: { ...existingPositions, ...modelPositions },
+            ...(updatedAnnotations ? { annotations: updatedAnnotations } : {}),
           },
         });
 
@@ -105,7 +130,7 @@ export function usePositionPersistence(): {
     (changes: NodeChange<Node>[]) => {
       // Apply all changes to nodes (handles selection, position, etc.).
       const updatedNodes = applyNodeChanges(changes, nodesRef.current);
-      setNodes(updatedNodes as ModelFlowNode[]);
+      setNodes(updatedNodes as (ModelFlowNode | AnnotationFlowNode)[]);
 
       // Extract position changes for persistence.
       const dragEndChanges = changes.filter(
@@ -127,10 +152,16 @@ export function usePositionPersistence(): {
       }
 
       const savedPositions = currentDomain.viewConfig.positions ?? {};
+      // Build annotation position lookup for no-op detection
+      const annotationPositions = new Map(
+        (currentDomain.viewConfig.annotations ?? []).map((a) => [`annotation-${a.id}`, { x: a.x, y: a.y }]),
+      );
 
       for (const change of dragEndChanges) {
         const newPos = change.position;
-        const oldPos = savedPositions[change.id];
+        const oldPos = change.id.startsWith('annotation-')
+          ? annotationPositions.get(change.id)
+          : savedPositions[change.id];
 
         // Skip if position unchanged (avoid no-op writes).
         if (
@@ -159,23 +190,49 @@ export function usePositionPersistence(): {
             return;
           }
 
-          const changedPositions = Object.fromEntries(pendingChangesRef.current);
+          // Partition changes: annotation nodes vs model nodes.
+          const modelPositions: Record<string, { x: number; y: number }> = {};
+          const annotationPositions: Array<{ id: string; x: number; y: number }> = [];
 
-          // Send only the delta — extension merges over disk positions to avoid
-          // concurrent tabs clobbering each other's saves.
-          const message: WebviewMessage = {
-            type: 'updatePositions',
-            payload: { positions: changedPositions },
-          };
-          vscode.postMessage(message);
+          for (const [nodeId, pos] of pendingChangesRef.current) {
+            if (nodeId.startsWith('annotation-')) {
+              annotationPositions.push({ id: nodeId.slice('annotation-'.length), x: pos.x, y: pos.y });
+            } else {
+              modelPositions[nodeId] = pos;
+            }
+          }
+
+          // Send model position delta.
+          if (Object.keys(modelPositions).length > 0) {
+            const message: WebviewMessage = {
+              type: 'updatePositions',
+              payload: { positions: modelPositions },
+            };
+            vscode.postMessage(message);
+          }
+
+          // Send annotation position updates.
+          for (const ann of annotationPositions) {
+            vscode.postMessage({
+              type: 'updateAnnotationPosition',
+              payload: ann,
+            } as WebviewMessage);
+          }
 
           // Optimistic local update with full merge for correct UI rendering.
           const existingPositions = latestDomain.viewConfig.positions ?? {};
+          const updatedAnnotations = annotationPositions.length > 0 && latestDomain.viewConfig.annotations
+            ? latestDomain.viewConfig.annotations.map((ann) => {
+                const moved = annotationPositions.find((a) => a.id === ann.id);
+                return moved ? { ...ann, x: moved.x, y: moved.y } : ann;
+              })
+            : latestDomain.viewConfig.annotations;
           setDomain({
             ...latestDomain,
             viewConfig: {
               ...latestDomain.viewConfig,
-              positions: { ...existingPositions, ...changedPositions },
+              positions: { ...existingPositions, ...modelPositions },
+              ...(updatedAnnotations ? { annotations: updatedAnnotations } : {}),
             },
           });
 

--- a/webview/lib/graphTransformer.ts
+++ b/webview/lib/graphTransformer.ts
@@ -20,6 +20,8 @@ import type {
 import type {
   ModelFlowNode,
   FkFlowEdge,
+  AnnotationFlowNode,
+  AnnotationFlowEdge,
   ColumnDisplay,
 } from '../types/graph';
 // ---------------------------------------------------------------------------
@@ -27,8 +29,8 @@ import type {
 // ---------------------------------------------------------------------------
 
 export interface TransformResult {
-  nodes: ModelFlowNode[];
-  edges: FkFlowEdge[];
+  nodes: (ModelFlowNode | AnnotationFlowNode)[];
+  edges: (FkFlowEdge | AnnotationFlowEdge)[];
 }
 
 /** Optional parameters for discrepancy overlay rendering. */
@@ -127,7 +129,7 @@ export function transformDomain(
 
   // --- Nodes ---------------------------------------------------------------
 
-  const nodes: ModelFlowNode[] = models.map((model) => {
+  const nodes: (ModelFlowNode | AnnotationFlowNode)[] = models.map((model) => {
     const columns = mapColumns(model);
     const position = positionMap.get(model.name) ?? DEFAULT_POSITION;
     const disc = discrepancyMap.get(model.name);
@@ -205,7 +207,7 @@ export function transformDomain(
   // Only include edges where both endpoints exist in the models/ghost nodes.
   const allNodeNames = new Set(positionMap.keys());
 
-  const edges: FkFlowEdge[] = relationships
+  const edges: (FkFlowEdge | AnnotationFlowEdge)[] = relationships
     .filter((rel) => allNodeNames.has(rel.fromModel) && allNodeNames.has(rel.toModel))
     .map((rel) => {
       const sourcePos = positionMap.get(rel.fromModel)!;
@@ -262,6 +264,46 @@ export function transformDomain(
           },
         });
       }
+    }
+  }
+
+  // --- Annotations ----------------------------------------------------------
+
+  const annotations = domain.viewConfig.annotations ?? [];
+  for (const ann of annotations) {
+    const annNodeId = `annotation-${ann.id}`;
+    nodes.push({
+      id: annNodeId,
+      type: 'annotation' as const,
+      position: { x: ann.x, y: ann.y },
+      data: {
+        annotationId: ann.id,
+        text: ann.text,
+        color: ann.color ?? 'yellow',
+        ...(ann.width != null ? { width: ann.width } : {}),
+        ...(ann.height != null ? { height: ann.height } : {}),
+        ...(ann.linkedModel ? { linkedModel: ann.linkedModel } : {}),
+        ...(readOnly ? { readOnly: true } : {}),
+      },
+    } as AnnotationFlowNode);
+
+    // Dashed edge to linked model (only if model exists in node set)
+    if (ann.linkedModel && positionMap.has(ann.linkedModel)) {
+      const annPos = { x: ann.x, y: ann.y };
+      const modelPos = positionMap.get(ann.linkedModel)!;
+      const { sourceSide, targetSide } = pickHandleSides(annPos, modelPos);
+      edges.push({
+        id: `ann-link-${ann.id}`,
+        type: 'annotationLink' as const,
+        source: annNodeId,
+        target: ann.linkedModel,
+        sourceHandle: `node-${sourceSide}-src`,
+        targetHandle: `node-${targetSide}-tgt`,
+        data: {
+          annotationId: ann.id,
+          targetModel: ann.linkedModel,
+        },
+      } as AnnotationFlowEdge);
     }
   }
 

--- a/webview/store/editorStore.ts
+++ b/webview/store/editorStore.ts
@@ -11,7 +11,7 @@ import { create } from 'zustand';
 import type { Viewport } from '@xyflow/react';
 import type { DisplayDomain, ExistingModelPreview, ManifestModelPreview } from '../../src/types/display';
 import type { DiscrepancyReport } from '../../src/types/discrepancy';
-import type { ModelFlowNode, FkFlowEdge, FkEdgeData } from '../types/graph';
+import type { ModelFlowNode, FkFlowEdge, FkEdgeData, AnnotationFlowNode, AnnotationFlowEdge } from '../types/graph';
 import type { ModelTemplate, Stage } from '../../src/types/semantic';
 import type { GroundTruth } from '../../src/types/syncPlan';
 
@@ -53,8 +53,16 @@ export interface NodeContextMenu {
   modelName: string;
 }
 
+/** Context menu state for annotation right-click. */
+export interface AnnotationContextMenu {
+  type: 'annotation';
+  x: number;
+  y: number;
+  annotationId: string;
+}
+
 /** Union of context menu states. */
-export type ContextMenuState = EdgeContextMenu | NodeContextMenu | null;
+export type ContextMenuState = EdgeContextMenu | NodeContextMenu | AnnotationContextMenu | null;
 
 export interface EditorState {
   /** Current search query for filtering/highlighting nodes. */
@@ -86,9 +94,11 @@ export interface EditorState {
   /** Error message from the extension host, if any. */
   error: string | null;
   /** React Flow nodes (local state for selection/drag). */
-  nodes: ModelFlowNode[];
+  nodes: (ModelFlowNode | AnnotationFlowNode)[];
   /** React Flow edges. */
-  edges: FkFlowEdge[];
+  edges: (FkFlowEdge | AnnotationFlowEdge)[];
+  /** Annotation currently being edited (auto-focus textarea), or null. */
+  editingAnnotationId: string | null;
   /** Available model templates loaded from semantic/templates/*.json. */
   templates: ModelTemplate[];
   /** Manifest models available to add to this domain (not already in domain). @deprecated Use existingModels. */
@@ -109,6 +119,14 @@ export interface EditorState {
   dragLineState: {
     sourceModelName: string;
     sourceColumnName: string;
+    sourceX: number;
+    sourceY: number;
+    currentX: number;
+    currentY: number;
+  } | null;
+  /** Active drag line state for linking an annotation to a model via drag. */
+  annotationLinkDrag: {
+    annotationId: string;
     sourceX: number;
     sourceY: number;
     currentX: number;
@@ -165,8 +183,12 @@ export interface EditorActions {
   setAddExistingModelDialogOpen: (open: boolean) => void;
   setDomain: (domain: DisplayDomain) => void;
   setError: (error: string | null) => void;
-  setNodes: (nodes: ModelFlowNode[]) => void;
-  setEdges: (edges: FkFlowEdge[]) => void;
+  setNodes: (nodes: (ModelFlowNode | AnnotationFlowNode)[]) => void;
+  setEdges: (edges: (FkFlowEdge | AnnotationFlowEdge)[]) => void;
+  /** Set the annotation currently being edited (auto-focus). */
+  setEditingAnnotationId: (id: string | null) => void;
+  /** Open context menu for an annotation at the given position. */
+  openAnnotationContextMenu: (x: number, y: number, annotationId: string) => void;
   setTemplates: (templates: ModelTemplate[]) => void;
   setManifestModels: (models: ManifestModelPreview[]) => void;
   setExistingModels: (models: ExistingModelPreview[]) => void;
@@ -194,6 +216,12 @@ export interface EditorActions {
   updateDragLineMouse: (mouseX: number, mouseY: number) => void;
   /** End drag line (on drop or cancel). */
   endDragLine: () => void;
+  /** Start drag line for annotation-to-model linking. */
+  startAnnotationLinkDrag: (annotationId: string, sourceX: number, sourceY: number) => void;
+  /** Update annotation link drag endpoint. */
+  updateAnnotationLinkDrag: (mouseX: number, mouseY: number) => void;
+  /** End annotation link drag. */
+  endAnnotationLinkDrag: () => void;
   /** Toggle the discrepancy overlay visibility. */
   setDiscrepancyVisible: (visible: boolean) => void;
   /** Set the stage being compared against. */
@@ -261,12 +289,14 @@ export const useEditorStore = create<EditorState & EditorActions>()((set) => ({
   templates: [],
   manifestModels: [],
   existingModels: [],
+  editingAnnotationId: null,
   contextMenu: null,
   _searchFocusFn: null,
   _autoLayoutFn: null,
   legendOpen: false,
   welcomeModalOpen: false,
   dragLineState: null,
+  annotationLinkDrag: null,
   discrepancyVisible: false,
   discrepancyCompareStage: null,
   discrepancyReport: null,
@@ -317,6 +347,8 @@ export const useEditorStore = create<EditorState & EditorActions>()((set) => ({
   setTemplates: (templates) => set({ templates }),
   setManifestModels: (models) => set({ manifestModels: models }),
   setExistingModels: (models) => set({ existingModels: models }),
+  setEditingAnnotationId: (id) => set({ editingAnnotationId: id }),
+  openAnnotationContextMenu: (x, y, annotationId) => set({ contextMenu: { type: 'annotation', x, y, annotationId } }),
   openEdgeContextMenu: (x, y, data) => set({ contextMenu: { type: 'edge', x, y, data } }),
   openNodeContextMenu: (x, y, modelName) => set({ contextMenu: { type: 'node', x, y, modelName } }),
   closeContextMenu: () => set({ contextMenu: null }),
@@ -356,6 +388,15 @@ export const useEditorStore = create<EditorState & EditorActions>()((set) => ({
         : {},
     ),
   endDragLine: () => set({ dragLineState: null }),
+  startAnnotationLinkDrag: (annotationId, sourceX, sourceY) =>
+    set({ annotationLinkDrag: { annotationId, sourceX, sourceY, currentX: sourceX, currentY: sourceY } }),
+  updateAnnotationLinkDrag: (mouseX, mouseY) =>
+    set((state) =>
+      state.annotationLinkDrag
+        ? { annotationLinkDrag: { ...state.annotationLinkDrag, currentX: mouseX, currentY: mouseY } }
+        : {},
+    ),
+  endAnnotationLinkDrag: () => set({ annotationLinkDrag: null }),
   setDiscrepancyVisible: (visible) => set({
     discrepancyVisible: visible,
     // Clear sync state when discrepancy overlay is hidden

--- a/webview/types/graph.ts
+++ b/webview/types/graph.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Node, Edge } from '@xyflow/react';
-import type { Cardinality, Layer, ModelRole, Stage } from '../../src/types/semantic';
+import type { AnnotationColor, Cardinality, Layer, ModelRole, Stage } from '../../src/types/semantic';
 import type { LayerConfig } from '../../src/types/layer';
 import type { ModelDiscrepancy } from '../../src/types/discrepancy';
 
@@ -110,3 +110,39 @@ export type FkEdgeData = {
 
 /** Typed React Flow edge for a semantic FK relationship. */
 export type FkFlowEdge = Edge<FkEdgeData, 'fk'>;
+
+// ---------------------------------------------------------------------------
+// AnnotationNode (canvas build notes)
+// ---------------------------------------------------------------------------
+
+/** Data payload for an AnnotationNode React Flow node. */
+export type AnnotationNodeData = {
+  annotationId: string;
+  text: string;
+  color: AnnotationColor;
+  width?: number;
+  height?: number;
+  linkedModel?: string;
+  /** Whether this annotation is in a read-only context (physical stage). */
+  readOnly?: boolean;
+  /** Index signature required by React Flow's Node generic. */
+  [key: string]: unknown;
+};
+
+/** Typed React Flow node for a canvas annotation. */
+export type AnnotationFlowNode = Node<AnnotationNodeData, 'annotation'>;
+
+// ---------------------------------------------------------------------------
+// AnnotationEdge (dashed link from annotation to model)
+// ---------------------------------------------------------------------------
+
+/** Data payload for the dashed edge linking an annotation to a model. */
+export type AnnotationEdgeData = {
+  annotationId: string;
+  targetModel: string;
+  /** Index signature required by React Flow's Edge generic. */
+  [key: string]: unknown;
+};
+
+/** Typed React Flow edge for an annotation-to-model link. */
+export type AnnotationFlowEdge = Edge<AnnotationEdgeData, 'annotationLink'>;


### PR DESCRIPTION
## Summary
- Adds post-it note style canvas annotations for temporary build notes while constructing models
- Annotations live in `viewConfig.annotations[]` (view-layer data, not semantic) with 5 colour options, drag-to-link to models, closest-side edge routing, and inline text editing
- Harness version bumped to 12 with annotation schema documentation for AI coding assistants

## What it looks like
- **Create**: `+ Add > New Note` button or double-click empty canvas
- **Edit**: Double-click the note text, Ctrl+Enter to commit
- **Link**: Drag the chain icon from a note to a model node (or use the toolbar dropdown)
- **Colour**: Click the `⋯` toolbar on hover → pick a colour
- **Delete**: `⋯` toolbar → Remove note
- Notes are exempt from ELK auto-layout, draggable with position persistence, and visible in the minimap with their actual colour

## Files changed (21)
**New components**: `AnnotationNode.tsx/css`, `AnnotationEdge.tsx`
**Types**: `semantic.ts` (Annotation, ViewConfig), `messages.ts` (4 message types), `graph.ts` (flow node/edge types)
**Extension host**: `SemanticEditorProvider.ts` (4 handlers), `domainService.ts` (parseViewConfig)
**Webview**: `App.tsx`, `graphTransformer.ts`, `editorStore.ts`, `usePositionPersistence.ts`, `Toolbar.tsx`, `ContextMenu.tsx`, `DragLine.tsx`, `Legend.tsx`
**Harness**: `harnessService.ts` (version 11→12, schema docs)

## Test plan
- [x] `npm run compile` — type-check passes
- [x] `npm run test` — all 327 tests pass
- [x] `npm run build` — esbuild succeeds
- [x] Manual testing in Extension Development Host (create, edit, drag, link, colour, delete, undo/redo)
- [x] Browser testing via dev-preview.html in Chrome
- [x] 3 code review agents run — 8 issues found, 6 fixed, 2 deferred (cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)