### PR TITLE
fix: prevent mass YAML tag modifications during git pull/checkout

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,16 +263,22 @@ export function activate(context: vscode.ExtensionContext): void {
     modelLibraryProvider.refresh();
   });
 
-  // Semantic file deleted → refresh tree + model library and clean up orphaned domain tags
-  const semanticDeletedSubscription = fileWatcherService.onSemanticFileDeleted(async () => {
+  // Semantic file deleted → refresh tree + model library, prompt for tag cleanup
+  // NOTE: reconcileAll() is NOT called automatically here because git operations
+  // (pull, checkout, merge, rebase) trigger file-delete events on Windows (delete-
+  // then-rename) and macOS (atomic rename via FSEvents), causing mass YAML
+  // modifications. Instead, offer to run the manual sync command.
+  const semanticDeletedSubscription = fileWatcherService.onSemanticFileDeleted(() => {
     treeProvider.refresh();
     modelLibraryProvider.refresh();
-    const result = await schemaTagService.reconcileAll();
-    if (result.removed > 0) {
-      void vscode.window.showInformationMessage(
-        `Domain file deleted — removed ${result.removed} orphaned tag(s) from YAML files.`,
-      );
-    }
+    void vscode.window.showInformationMessage(
+      'Domain file deleted. Run "Sync Domain Tags" to clean up orphaned YAML tags.',
+      'Sync Now',
+    ).then(choice => {
+      if (choice === 'Sync Now') {
+        void vscode.commands.executeCommand('dbtSemantic.syncDomainTags');
+      }
+    });
   });
 
   // Logical model file changed → refresh domains referencing that model + model library

--- a/src/services/schemaTagService.ts
+++ b/src/services/schemaTagService.ts
@@ -25,6 +25,7 @@ const DOMAIN_TAG_PREFIX = 'domain:';
 const EXCLUDED_DIRS = new Set([
   'node_modules', 'target', '.git', '.venv', 'venv',
   '__pycache__', 'dist', '.tox', '.mypy_cache',
+  'dbt_packages', 'dbt_modules',
 ]);
 
 export class SchemaTagService {


### PR DESCRIPTION
## Summary
- **Root cause**: `reconcileAll()` was triggered by `onSemanticFileDeleted` whenever domain JSON files changed. Git operations (pull, checkout, merge, rebase) fire delete events due to atomic file replacement (delete-then-rename on Windows, FSEvents on macOS), causing mass YAML modifications across the workspace.
- **Fix**: Replace automatic `reconcileAll()` with a notification offering "Sync Now" — user explicitly triggers reconciliation only when needed.
- **Also**: Added `dbt_packages` and `dbt_modules` to YAML index exclusion list to prevent writing domain tags into vendored package files.

## Context
PR #20 fixed the reactive `diffAndSyncTags()` path in `sendDomainData()`, but missed the `onSemanticFileDeleted` → `reconcileAll()` path in `extension.ts`. This was the remaining trigger for the mass YAML modification bug reported by Jason after `git pull`.

## Test plan
- [x] `npm run compile` — type-check clean
- [x] `npm test` — 333/333 tests pass
- [ ] Manual: open domain editor, `git pull` with domain file changes, verify no YAML files modified
- [ ] Manual: delete a domain JSON file, verify "Sync Now" notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)