### PR TITLE
fix: exclude annotation nodes from ELK layer bound calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "erd-studio",
   "displayName": "ERD Studio",
   "description": "Visual ERD designer for dbt projects. Design your data warehouse across two stages — Logical (columns, types, FK design) and Physical (read-only manifest view) — with cross-stage discrepancy comparison.",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "publisher": "liamwynne",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/webview/components/Toolbar/Toolbar.tsx
+++ b/webview/components/Toolbar/Toolbar.tsx
@@ -303,12 +303,12 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
 
     try {
       const sp = SPACING_PRESETS[spacingPreset];
-      const effectiveBound = partitionStrategy === 'auto'
-        ? detectLayerBound(nodes.length)
-        : layerBound;
       // Filter to model nodes/FK edges only — annotations are exempt from auto-layout.
       const modelNodes = nodes.filter((n): n is import('../../types/graph').ModelFlowNode => n.type === 'model');
       const fkEdges = edges.filter((e): e is import('../../types/graph').FkFlowEdge => e.type === 'fk');
+      const effectiveBound = partitionStrategy === 'auto'
+        ? detectLayerBound(modelNodes.length)
+        : layerBound;
       const positions = await runElkLayout(
         modelNodes,
         fkEdges,
@@ -614,14 +614,14 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
                     <input
                       type="number"
                       className={`toolbar__lp-input${partitionStrategy === 'auto' ? ' toolbar__lp-input--auto' : ''}`}
-                      value={partitionStrategy === 'auto' ? detectLayerBound(nodes.length) : layerBound}
+                      value={partitionStrategy === 'auto' ? detectLayerBound(nodes.filter((n) => n.type === 'model').length) : layerBound}
                       min={1}
                       max={20}
                       disabled={partitionStrategy === 'auto'}
                       onChange={(e) => { setLayerBound(Math.max(1, Math.min(20, Number(e.target.value)))); setLayoutDirty(true); }}
                     />
                     {partitionStrategy === 'auto' ? (
-                      <span className="toolbar__lp-desc">auto — {detectLayerBound(nodes.length)} for {nodes.length} models</span>
+                      <span className="toolbar__lp-desc">auto — {detectLayerBound(nodes.filter((n) => n.type === 'model').length)} for {nodes.filter((n) => n.type === 'model').length} models</span>
                     ) : (
                       <span className="toolbar__lp-desc">lower = wider layout, higher = taller layout</span>
                     )}


### PR DESCRIPTION
## Summary
- `detectLayerBound(nodes.length)` in `Toolbar.tsx` was counting annotation (build note) nodes alongside model nodes, inflating the Coffman-Graham layer bound passed to ELK
- This caused auto-layout to produce incorrect (wider/shorter) layouts when canvas notes were present
- Fixed 3 locations: the layout execution path, the options panel input value, and the description text

## Test plan
- [x] All 333 unit tests pass (`npm run test`)
- [x] TypeScript compilation clean (`npm run compile`)
- [ ] Manual: open a domain with annotations, run auto-layout — verify layout matches domains without annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)