### PR TITLE
release: v0.6.27 — inline column delete + edge/note polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the ERD Studio extension.
+
+## 0.6.27 — 2026-04-21
+
+### Added
+
+- **Inline column delete on the canvas** — hover any column on a model node to reveal a one-click delete button. Deleting a column also cascades to any relationships that referenced it, matching the existing behaviour for deleted models.
+
+### Fixed
+
+- **Self-reference relationships** (a model linking to itself) now render as a proper cubic-bezier loop arcing over the top-right corner of the node, instead of collapsing into the node body.
+- **Double-click to add note** is now detected reliably across the entire canvas. The previous check silently dropped the gesture whenever the click target wasn't the exact React Flow pane element (for example, when an overlay or child element intercepted it). The "New Note" dropdown item also now advertises the gesture via tooltip.
+- **Marketplace README** — header icon, demo GIF, and license badge now render correctly on the extension page. Images are served from a public assets repo (the source repo remains private) and the license badge is a static MIT badge.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="media/icon.png" width="128" height="128" alt="ERD Studio" />
+  <img src="https://raw.githubusercontent.com/liam-machine/erd-studio-assets/main/icon.png" width="128" height="128" alt="ERD Studio" />
 </p>
 
 <h1 align="center">ERD Studio</h1>
@@ -12,7 +12,7 @@
   <a href="https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio"><img src="https://img.shields.io/visual-studio-marketplace/v/liamwynne.erd-studio?label=Marketplace&color=0078d4" alt="VS Marketplace Version" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio"><img src="https://img.shields.io/visual-studio-marketplace/i/liamwynne.erd-studio?color=0078d4" alt="Installs" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio"><img src="https://img.shields.io/visual-studio-marketplace/r/liamwynne.erd-studio?color=0078d4" alt="Rating" /></a>
-  <a href="https://github.com/liam-machine/erd-studio/blob/main/LICENSE"><img src="https://img.shields.io/github/license/liam-machine/erd-studio?color=0078d4&_v=2" alt="License" /></a>
+  <img src="https://img.shields.io/badge/license-MIT-0078d4" alt="License: MIT" />
 </p>
 
 <p align="center">
@@ -30,7 +30,7 @@
 </p>
 
 <p align="center">
-  <img src="media/demo.gif" width="800" alt="ERD Studio demo — Logical stage, Physical stage, and Discrepancy overlay" />
+  <img src="https://raw.githubusercontent.com/liam-machine/erd-studio-assets/main/demo.gif" width="800" alt="ERD Studio demo — Logical stage, Physical stage, and Discrepancy overlay" />
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "erd-studio",
   "displayName": "ERD Studio",
   "description": "Visual ERD designer for dbt projects. Design your data warehouse across two stages — Logical (columns, types, FK design) and Physical (read-only manifest view) — with cross-stage discrepancy comparison.",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "publisher": "liamwynne",
   "license": "MIT",
   "icon": "media/icon.png",

--- a/src/providers/SemanticEditorProvider.ts
+++ b/src/providers/SemanticEditorProvider.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { DomainService } from '../services/domainService';
+import { DomainService, relationshipReferencesColumn } from '../services/domainService';
 import { compare as compareStages } from '../services/discrepancyService';
 import { ManifestService } from '../services/manifestService';
 import { YmlParserService } from '../services/ymlParserService';
@@ -1268,35 +1268,46 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
       const text = document.getText();
       const parsed = JSON.parse(text) as Record<string, unknown>;
 
-      // V5: write to central model file
+      // V5: write to central model file, cascade orphaned relationships in the domain.
+      // No-op silently if the column or model is already gone (e.g. spam-clicked delete).
       if (this.isDomainV5(parsed)) {
-        await this.applyModelEdit(document, webview, payload.modelName, (model) => {
-          const columns = model.columns ?? [];
-          const idx = columns.findIndex((c) => c.name === payload.columnName);
-          if (idx === -1) throw new Error(`Column "${payload.columnName}" not found.`);
-          columns.splice(idx, 1);
-        });
+        await this.applyModelEdit(
+          document,
+          webview,
+          payload.modelName,
+          (model) => {
+            const columns = model.columns ?? [];
+            const idx = columns.findIndex((c) => c.name === payload.columnName);
+            if (idx === -1) return;
+            columns.splice(idx, 1);
+          },
+          (sec) => {
+            const rels = (sec.relationships ?? []) as Array<Record<string, unknown>>;
+            sec.relationships = rels.filter(
+              (rel) => !relationshipReferencesColumn(rel, payload.modelName, payload.columnName),
+            );
+          },
+        );
         return;
       }
 
-      // V4: legacy inline path
+      // V4: legacy inline path. Silent no-op if the model or column is already gone.
       const section = this.getStageSection(parsed, stage);
       const models = (section.models ?? []) as Array<Record<string, unknown>>;
       const model = models.find((m) => m.name === payload.modelName);
-      if (!model) {
-        webview.postMessage({ type: 'error', payload: { message: `Model "${payload.modelName}" not found.` } });
-        return;
-      }
+      if (!model) return;
 
       const columns = (model.columns ?? []) as Array<Record<string, unknown>>;
       const columnIndex = columns.findIndex((c) => c.name === payload.columnName);
-      if (columnIndex === -1) {
-        webview.postMessage({ type: 'error', payload: { message: `Column "${payload.columnName}" not found.` } });
-        return;
-      }
+      if (columnIndex === -1) return;
 
       columns.splice(columnIndex, 1);
       model.columns = columns;
+
+      const relationships = (section.relationships ?? []) as Array<Record<string, unknown>>;
+      section.relationships = relationships.filter(
+        (rel) => !relationshipReferencesColumn(rel, payload.modelName, payload.columnName),
+      );
 
       const updatedText = JSON.stringify(parsed, null, 2) + '\n';
       const edit = new vscode.WorkspaceEdit();

--- a/src/services/domainService.ts
+++ b/src/services/domainService.ts
@@ -543,6 +543,21 @@ export function derivePhysicalRelationships(
 }
 
 /**
+ * True if a relationship references the given (model, column) on either endpoint.
+ * Used to cascade-delete relationships when a column is removed.
+ */
+export function relationshipReferencesColumn(
+  rel: { fromModel?: unknown; fromColumn?: unknown; toModel?: unknown; toColumn?: unknown },
+  modelName: string,
+  columnName: string,
+): boolean {
+  return (
+    (rel.fromModel === modelName && rel.fromColumn === columnName) ||
+    (rel.toModel === modelName && rel.toColumn === columnName)
+  );
+}
+
+/**
  * Derive cardinality for a single relationship edge based on uniqueness tests.
  */
 function deriveCardinality(

--- a/test/fixtures/dbt-project/erd-studio/logical-models/dim_project.yml
+++ b/test/fixtures/dbt-project/erd-studio/logical-models/dim_project.yml
@@ -17,3 +17,7 @@ columns:
   - name: project_code
     dataType: VARCHAR
     description: Business project code
+  - name: parent_project_id
+    dataType: INT
+    description: Parent project for hierarchical rollups (self-reference)
+    isForeignKey: true

--- a/test/fixtures/dbt-project/erd-studio/silver/showcase.json
+++ b/test/fixtures/dbt-project/erd-studio/silver/showcase.json
@@ -40,16 +40,38 @@
         "toModel": "dim_customer",
         "toColumn": "customer_id",
         "cardinality": "many-to-one"
+      },
+      {
+        "fromModel": "dim_project",
+        "fromColumn": "parent_project_id",
+        "toModel": "dim_project",
+        "toColumn": "project_id",
+        "cardinality": "many-to-one"
       }
     ]
   },
   "viewConfig": {
     "positions": {
-      "fct_work_events": { "x": 500, "y": 200 },
-      "dim_project": { "x": 950, "y": -10 },
-      "dim_work_lot": { "x": 950, "y": 250 },
-      "dim_customer": { "x": 50, "y": 0 },
-      "dim_date": { "x": 50, "y": 370 }
+      "fct_work_events": {
+        "x": 500,
+        "y": 200
+      },
+      "dim_project": {
+        "x": 950,
+        "y": -10
+      },
+      "dim_work_lot": {
+        "x": 950,
+        "y": 250
+      },
+      "dim_customer": {
+        "x": 50,
+        "y": 0
+      },
+      "dim_date": {
+        "x": 50,
+        "y": 370
+      }
     },
     "annotations": []
   }

--- a/test/unit/domainService.test.ts
+++ b/test/unit/domainService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import * as path from 'path';
-import { DomainService, derivePhysicalRelationships } from '../../src/services/domainService';
+import { DomainService, derivePhysicalRelationships, relationshipReferencesColumn } from '../../src/services/domainService';
 import type { LayerService } from '../../src/services/layerService';
 import type { LayerConfig } from '../../src/types/layer';
 import type { ManifestData, ManifestRelationshipTest } from '../../src/types/manifest';
@@ -519,6 +519,47 @@ describe('DomainService', () => {
     it('returns empty array when no relationship tests exist', () => {
       const result = derivePhysicalRelationships([], models, new Map(), new Map());
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('relationshipReferencesColumn', () => {
+    const rel = {
+      fromModel: 'fct_orders',
+      fromColumn: 'customer_id',
+      toModel: 'dim_customer',
+      toColumn: 'customer_id',
+    };
+
+    it('matches when the column is the from-endpoint', () => {
+      expect(relationshipReferencesColumn(rel, 'fct_orders', 'customer_id')).toBe(true);
+    });
+
+    it('matches when the column is the to-endpoint', () => {
+      expect(relationshipReferencesColumn(rel, 'dim_customer', 'customer_id')).toBe(true);
+    });
+
+    it('does not match when only the model name matches', () => {
+      expect(relationshipReferencesColumn(rel, 'fct_orders', 'order_id')).toBe(false);
+    });
+
+    it('does not match when only the column name matches a different model', () => {
+      expect(relationshipReferencesColumn(rel, 'dim_product', 'customer_id')).toBe(false);
+    });
+
+    it('matches a self-referencing relationship on either endpoint', () => {
+      const selfRef = {
+        fromModel: 'dim_employee',
+        fromColumn: 'employee_id',
+        toModel: 'dim_employee',
+        toColumn: 'manager_id',
+      };
+      expect(relationshipReferencesColumn(selfRef, 'dim_employee', 'employee_id')).toBe(true);
+      expect(relationshipReferencesColumn(selfRef, 'dim_employee', 'manager_id')).toBe(true);
+      expect(relationshipReferencesColumn(selfRef, 'dim_employee', 'other_col')).toBe(false);
+    });
+
+    it('handles relationships with missing endpoint fields without throwing', () => {
+      expect(relationshipReferencesColumn({}, 'fct_orders', 'customer_id')).toBe(false);
     });
   });
 });

--- a/webview/App.tsx
+++ b/webview/App.tsx
@@ -767,13 +767,23 @@ function EditorCanvas() {
     };
   }, [annotationLinkDrag, updateAnnotationLinkDrag, endAnnotationLinkDrag, vscode]);
 
-  // Handle double-click on blank canvas to create a new annotation
+  // Handle double-click on blank canvas to create a new annotation.
+  // Robust detection: accept dblclicks anywhere EXCEPT inside a node, edge, or
+  // floating React Flow panel (MiniMap, Controls, Toolbar). This lets dblclicks
+  // on the background dots/grid still create a note, which the stricter
+  // `classList.contains('react-flow__pane')` check would drop.
   const onPaneDoubleClick = useCallback(
     (event: React.MouseEvent) => {
       if (domain?.readOnly) return;
-      // Only trigger on actual pane clicks, not double-clicks that bubbled from nodes
-      const target = event.target as HTMLElement;
-      if (!target.classList.contains('react-flow__pane')) return;
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (
+        target.closest(
+          '.react-flow__node, .react-flow__edge, .react-flow__panel, .react-flow__minimap, .react-flow__controls',
+        )
+      ) {
+        return;
+      }
 
       const position = screenToFlowPosition({ x: event.clientX, y: event.clientY });
       const id = crypto.randomUUID();

--- a/webview/components/Graph/FkEdge.tsx
+++ b/webview/components/Graph/FkEdge.tsx
@@ -44,6 +44,13 @@ const PATH_GAP = 20;
 /** How far (px) from the node boundary to place the cardinality label. */
 const LABEL_OFFSET = 8;
 
+/**
+ * Radius (px) of the arc drawn for self-reference edges. The loop exits the
+ * top of the node, arcs outward past the top-right corner, and re-enters the
+ * right side. A larger radius means the loop extends further from the node.
+ */
+const SELF_LOOP_RADIUS = 55;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -132,7 +139,7 @@ function FkEdgeComponent({
   );
 
   if (!data) return null;
-  const { cardinality, stage, discrepancyStatus, fromModel, toModel, dimmed, readOnly } = data;
+  const { cardinality, stage, discrepancyStatus, fromModel, toModel, dimmed, readOnly, isSelfLoop } = data;
 
   // For cardinality mismatch edges, pull the mismatch details from the report
   // The edge data only has status — we need to find the original relationship discrepancy
@@ -183,15 +190,21 @@ function FkEdgeComponent({
   const src = offsetPoint(adjustedSourceX, adjustedSourceY, sourcePosition, PATH_GAP);
   const tgt = offsetPoint(adjustedTargetX, adjustedTargetY, targetPosition, PATH_GAP);
 
-  const [edgePath] = getSmoothStepPath({
-    sourceX: src.x,
-    sourceY: src.y,
-    targetX: tgt.x,
-    targetY: tgt.y,
-    sourcePosition,
-    targetPosition,
-    borderRadius: 8,
-  });
+  // Self-refs use a cubic bezier arcing outward past the top-right corner.
+  // Both control points are pulled diagonally north-east so the curve sweeps
+  // *around* the corner instead of sagging through it — perpendicular-only
+  // control points let the midsection collapse onto the node corner.
+  const edgePath = isSelfLoop
+    ? `M ${src.x},${src.y} C ${src.x + SELF_LOOP_RADIUS},${src.y - SELF_LOOP_RADIUS} ${tgt.x + SELF_LOOP_RADIUS},${tgt.y - SELF_LOOP_RADIUS} ${tgt.x},${tgt.y}`
+    : getSmoothStepPath({
+        sourceX: src.x,
+        sourceY: src.y,
+        targetX: tgt.x,
+        targetY: tgt.y,
+        sourcePosition,
+        targetPosition,
+        borderRadius: 8,
+      })[0];
 
   const statusClass = discrepancyStatus
     ? `fk-edge--discrepancy-${discrepancyStatus}`
@@ -237,9 +250,17 @@ function FkEdgeComponent({
   const srcLabel = offsetPoint(adjustedSourceX, adjustedSourceY, sourcePosition, LABEL_OFFSET);
   const tgtLabel = offsetPoint(adjustedTargetX, adjustedTargetY, targetPosition, LABEL_OFFSET);
 
-  // Midpoint for cardinality mismatch badge
-  const midX = (adjustedSourceX + adjustedTargetX) / 2;
-  const midY = (adjustedSourceY + adjustedTargetY) / 2;
+  // Midpoint for cardinality mismatch badge / swap button.
+  // For self-loops the straight midpoint falls inside the node; instead we
+  // compute the bezier's exact midpoint at t=0.5, which sits northeast of
+  // the top-right corner. (Derived from B(0.5) with diagonal control points:
+  // the R terms aggregate to 0.75·R along each axis.)
+  const midX = isSelfLoop
+    ? (src.x + tgt.x) / 2 + SELF_LOOP_RADIUS * 0.75
+    : (adjustedSourceX + adjustedTargetX) / 2;
+  const midY = isSelfLoop
+    ? (src.y + tgt.y) / 2 - SELF_LOOP_RADIUS * 0.75
+    : (adjustedSourceY + adjustedTargetY) / 2;
 
   return (
     <>

--- a/webview/components/Graph/ModelNode.css
+++ b/webview/components/Graph/ModelNode.css
@@ -408,6 +408,34 @@
   border-radius: 2px;
 }
 
+/* Inline column delete button — fades in on row hover, single-click delete (undo via Cmd+Z). */
+.model-node__col-delete {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease, background 0.1s ease;
+}
+
+.model-node__column:hover .model-node__col-delete {
+  opacity: 1;
+}
+
+.model-node__col-delete:hover {
+  background: rgba(239, 68, 68, 0.25);
+}
+
 /* SCD type and additive type column badges (F502) */
 .model-node__col-badge {
   flex-shrink: 0;

--- a/webview/components/Graph/ModelNode.tsx
+++ b/webview/components/Graph/ModelNode.tsx
@@ -215,6 +215,11 @@ function ColumnRow({ column, modelName, readOnly, existingColumnNames, discrepan
     startEdit('dataType');
   }, [startEdit]);
 
+  const handleDelete = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    send({ type: 'removeColumn', payload: { modelName, columnName: column.name } });
+  }, [send, modelName, column.name]);
+
   // Reset drop target state when drag ends
   useEffect(() => {
     if (!dragSourceModel) setIsDropTarget(false);
@@ -471,6 +476,18 @@ function ColumnRow({ column, modelName, readOnly, existingColumnNames, discrepan
         >
           {ADDITIVE_BADGE[column.additiveType]}
         </span>
+      )}
+      {!readOnly && !editingField && (
+        <button
+          type="button"
+          className="model-node__col-delete nodrag"
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={handleDelete}
+          title="Delete column"
+          aria-label={`Delete column ${column.name}`}
+        >
+          ×
+        </button>
       )}
       <ColumnTooltip column={column} anchorRef={elementRef} visible={showTooltip} />
     </div>

--- a/webview/components/Toolbar/Toolbar.tsx
+++ b/webview/components/Toolbar/Toolbar.tsx
@@ -780,6 +780,7 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
                       className="toolbar__dropdown-item"
                       onClick={handleNewAnnotation}
                       role="menuitem"
+                      title="Create a note at the viewport centre (or double-click blank canvas)"
                     >
                       New Note
                     </button>

--- a/webview/lib/graphTransformer.ts
+++ b/webview/lib/graphTransformer.ts
@@ -210,9 +210,14 @@ export function transformDomain(
   const edges: (FkFlowEdge | AnnotationFlowEdge)[] = relationships
     .filter((rel) => allNodeNames.has(rel.fromModel) && allNodeNames.has(rel.toModel))
     .map((rel) => {
+      const isSelfLoop = rel.fromModel === rel.toModel;
       const sourcePos = positionMap.get(rel.fromModel)!;
       const targetPos = positionMap.get(rel.toModel)!;
-      const { sourceSide, targetSide } = pickHandleSides(sourcePos, targetPos);
+      // Self-refs attach to top (source) and right (target) handles so the
+      // FkEdge component can arc the path over the top-right corner.
+      const { sourceSide, targetSide } = isSelfLoop
+        ? { sourceSide: 'top' as Side, targetSide: 'right' as Side }
+        : pickHandleSides(sourcePos, targetPos);
 
       const relKey = `${rel.fromModel}|${rel.fromColumn}|${rel.toModel}|${rel.toColumn}`;
       const discStatus = relDiscrepancyMap.get(relKey);
@@ -233,6 +238,7 @@ export function transformDomain(
           stage,
           ...(readOnly ? { readOnly: true } : {}),
           ...(discStatus ? { discrepancyStatus: discStatus } : {}),
+          ...(isSelfLoop ? { isSelfLoop: true } : {}),
         },
       };
     });
@@ -245,7 +251,10 @@ export function transformDomain(
         const targetPos = positionMap.get(rd.toModel);
         if (!sourcePos || !targetPos) continue;
 
-        const { sourceSide, targetSide } = pickHandleSides(sourcePos, targetPos);
+        const isSelfLoop = rd.fromModel === rd.toModel;
+        const { sourceSide, targetSide } = isSelfLoop
+          ? { sourceSide: 'top' as Side, targetSide: 'right' as Side }
+          : pickHandleSides(sourcePos, targetPos);
         edges.push({
           id: `ghost-fk-${rd.fromModel}-${rd.fromColumn}-${rd.toModel}-${rd.toColumn}`,
           type: 'fk' as const,
@@ -261,6 +270,7 @@ export function transformDomain(
             cardinality: rd.sourceCardinality ?? rd.targetCardinality ?? 'many-to-one',
             stage,
             discrepancyStatus: 'missing',
+            ...(isSelfLoop ? { isSelfLoop: true } : {}),
           },
         });
       }

--- a/webview/types/graph.ts
+++ b/webview/types/graph.ts
@@ -104,6 +104,8 @@ export type FkEdgeData = {
   dimmed?: boolean;
   /** Whether the edge is in a read-only context (physical stage). */
   readOnly?: boolean;
+  /** True when source === target — renders a loop arc over the top-right corner. */
+  isSelfLoop?: boolean;
   /** Index signature required by React Flow's Edge generic. */
   [key: string]: unknown;
 };


### PR DESCRIPTION
## Summary

Release bundling the four commits since v0.6.26, plus the first CHANGELOG.md entry.

**Added**
- Inline column delete on the canvas — hover a column, click to remove. Cascades to relationships that referenced it.

**Fixed**
- Self-reference relationships now render as a proper cubic-bezier loop over the top-right corner instead of collapsing into the node body.
- Double-click-to-add-note is reliable across the canvas (previous pane-only check dropped clicks on overlays/children).
- Marketplace README header icon, demo GIF, and license badge now render on the extension page — images served from a new public `liam-machine/erd-studio-assets` repo, license is a static MIT badge.

## Test plan

- [ ] `npm run compile && npm run build && npm run test` all green in CI
- [ ] After merge: `vsce publish` from terminal, then hard-refresh the marketplace page and confirm images + license badge render, and Changelog tab shows v0.6.27 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)