### PR TITLE
refactor: hide stub toggle from detail panel

### DIFF
--- a/webview/components/DetailPanel/DetailPanel.tsx
+++ b/webview/components/DetailPanel/DetailPanel.tsx
@@ -278,20 +278,6 @@ export function DetailPanel() {
         </div>
       )}
 
-      {/* Stub toggle */}
-      {!isReadOnly && (
-        <div className="detail-panel__section detail-panel__section--stub">
-          <label className="detail-panel__stub-label" title="Show only PK/NK columns on the canvas. Extra physical columns are also ignored during sync comparison.">
-            <input
-              type="checkbox"
-              checked={domain?.stubColumns?.includes(model.name) ?? false}
-              onChange={(e) => vscode.postMessage({ type: 'toggleStubColumns', payload: { modelName: model.name, stub: e.target.checked } })}
-            />
-            Stub
-          </label>
-        </div>
-      )}
-
       {/* Grain statement */}
       {!isReadOnly && (
         <div className="detail-panel__section">


### PR DESCRIPTION
## Summary
- Hide the per-model **Stub** toggle from the detail panel while we decide whether to retire the feature entirely.
- Only the JSX is removed. The `stubColumns` field on the domain, the `toggleStubColumns` message handler, and the graph-transformer logic that filters non-key columns all stay — so models already stubbed continue to render the same way.
- Keeping the data path intact avoids a schema change that would require a `HARNESS_VERSION` bump.

## Test plan
- [ ] Detail panel no longer shows the **Stub** checkbox for selected models
- [ ] Any models with pre-existing `stubColumns` entries still render with PK/NK columns only on the canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)