### PR TITLE
feat: add multi-select and box-select mode for tables

### DIFF
--- a/webview/App.css
+++ b/webview/App.css
@@ -1,0 +1,12 @@
+/**
+ * App-level (editor canvas) styles.
+ *
+ * Behaviour/state rules that depend on application state (canvas mode, etc.).
+ * Theme-token rules live in webview/styles/theme.css.
+ */
+
+/* Select mode — crosshair cursor on the empty canvas. Nodes keep their own
+   grab cursor so hovering a table in select mode still shows a move cursor. */
+.editor-canvas--select-mode .react-flow__pane {
+  cursor: crosshair;
+}

--- a/webview/App.tsx
+++ b/webview/App.tsx
@@ -22,6 +22,7 @@ import {
   type OnSelectionChangeFunc,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import './App.css';
 
 import { useMessageBus, type ExtensionMessage } from './hooks/useMessageBus';
 import { usePositionPersistence } from './hooks/usePositionPersistence';
@@ -111,6 +112,8 @@ function EditorCanvas() {
   const setEditingAnnotationId = useEditorStore((s) => s.setEditingAnnotationId);
   const selectedAnnotation = useEditorStore((s) => s.selectedAnnotation);
   const selectAnnotation = useEditorStore((s) => s.selectAnnotation);
+  const canvasMode = useEditorStore((s) => s.canvasMode);
+  const setCanvasMode = useEditorStore((s) => s.setCanvasMode);
   const annotationLinkDrag = useEditorStore((s) => s.annotationLinkDrag);
   const updateAnnotationLinkDrag = useEditorStore((s) => s.updateAnnotationLinkDrag);
   const endAnnotationLinkDrag = useEditorStore((s) => s.endAnnotationLinkDrag);
@@ -378,6 +381,12 @@ function EditorCanvas() {
           setSelectedEdges([]);
           setSelectedEdge(null);
           setHighlightedColumns(new Set());
+          return;
+        }
+
+        // Nothing selected — if in select mode, return to pan mode
+        if (canvasMode === 'select') {
+          setCanvasMode('pan');
         }
         return;
       }
@@ -387,6 +396,21 @@ function EditorCanvas() {
         e.preventDefault();
         triggerAutoLayout();
         return;
+      }
+
+      // V / S: Canvas mode toggle (Figma-style)
+      // No modifier keys — only fires when no input has focus (guarded above).
+      if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
+        if ((e.key === 'v' || e.key === 'V') && canvasMode !== 'pan') {
+          e.preventDefault();
+          setCanvasMode('pan');
+          return;
+        }
+        if ((e.key === 's' || e.key === 'S') && canvasMode !== 'select' && domain && !domain.readOnly) {
+          e.preventDefault();
+          setCanvasMode('select');
+          return;
+        }
       }
 
       // Alt+1/2: Switch stage tabs
@@ -503,6 +527,8 @@ function EditorCanvas() {
     selectedColumns,
     clearColumnSelection,
     setEditingColumn,
+    canvasMode,
+    setCanvasMode,
     // Note: vscode is omitted as it's a stable ref from useVsCodeApi
   ]);
 
@@ -595,12 +621,18 @@ function EditorCanvas() {
         };
       });
 
-      // If we have a selected node, preserve the selection in the new nodes
-      if (currentSelectedNode) {
-        const selectedIdx = newNodes.findIndex((n) => n.id === currentSelectedNode);
-        if (selectedIdx !== -1) {
-          newNodes[selectedIdx] = { ...newNodes[selectedIdx], selected: true };
-        }
+      // Preserve React Flow's current selection across this rebuild.
+      // Without this, any store change that re-triggers this effect (e.g. setSelectedEdges from
+      // onSelectionChange firing during a rubber-band drag) wipes the multi-selection React Flow
+      // just applied via applyNodeChanges. Read store state directly to avoid adding `nodes` to
+      // the dep array (which would cause an infinite loop since we call setNodes below).
+      const preserveSelected = new Set<string>();
+      if (currentSelectedNode) preserveSelected.add(currentSelectedNode);
+      for (const n of useEditorStore.getState().nodes) {
+        if (n.selected) preserveSelected.add(n.id);
+      }
+      if (preserveSelected.size > 0) {
+        newNodes = newNodes.map((n) => preserveSelected.has(n.id) ? { ...n, selected: true } : n);
       }
 
       // Clear stale edge selections (edges that no longer exist after domain update)
@@ -852,8 +884,12 @@ function EditorCanvas() {
 
   // --- Graph canvas ----------------------------------------------------------
 
+  const selectModeActive = canvasMode === 'select' && !domain.readOnly;
   return (
-    <div style={{ width: '100%', height: '100%' }}>
+    <div
+      className={`editor-canvas${selectModeActive ? ' editor-canvas--select-mode' : ''}`}
+      style={{ width: '100%', height: '100%' }}
+    >
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -873,8 +909,8 @@ function EditorCanvas() {
         selectionMode={SelectionMode.Partial}
         zoomOnDoubleClick={domain.readOnly}
         nodesDraggable={domain.positionDraggable ?? !domain.readOnly}
-        panOnDrag={!shiftHeld}
-        selectionOnDrag={shiftHeld && !domain.readOnly}
+        panOnDrag={!selectModeActive && !shiftHeld}
+        selectionOnDrag={(selectModeActive || shiftHeld) && !domain.readOnly}
         selectionKeyCode={null}
         multiSelectionKeyCode="Shift"
         proOptions={{ hideAttribution: true }}

--- a/webview/components/Graph/ModelNode.css
+++ b/webview/components/Graph/ModelNode.css
@@ -44,6 +44,20 @@
   box-shadow: 0 0 0 2px var(--discrepancy-extra), 0 0 12px 2px rgba(245, 158, 11, 0.35);
 }
 
+/* Selected — stage-coloured ring + glow. Applies to single and multi-select. */
+.model-node--selected {
+  box-shadow: 0 0 0 2px var(--stage-logical), 0 0 10px 1px rgba(96, 165, 250, 0.4);
+}
+
+.model-node--physical.model-node--selected {
+  box-shadow: 0 0 0 2px var(--stage-physical), 0 0 10px 1px rgba(34, 197, 94, 0.4);
+}
+
+/* Discrepancy-extra takes visual priority over selected so the amber glow wins. */
+.model-node--disc-extra.model-node--selected {
+  box-shadow: 0 0 0 2px var(--discrepancy-extra), 0 0 12px 2px rgba(245, 158, 11, 0.35);
+}
+
 /* Search dimming (F402) — applied when node doesn't match search query */
 .model-node--dimmed {
   opacity: 0.25;

--- a/webview/components/Graph/ModelNode.tsx
+++ b/webview/components/Graph/ModelNode.tsx
@@ -573,7 +573,7 @@ function ModelNodeComponent({ data, selected }: NodeProps<ModelFlowNode>) {
 
   return (
     <div
-      className={`model-node model-node--${stageClass}${dimmed ? ' model-node--dimmed' : ''}${readOnly ? ' model-node--readonly' : ''}${isDiscExtra ? ' model-node--disc-extra' : ''}`}
+      className={`model-node model-node--${stageClass}${dimmed ? ' model-node--dimmed' : ''}${readOnly ? ' model-node--readonly' : ''}${isDiscExtra ? ' model-node--disc-extra' : ''}${selected ? ' model-node--selected' : ''}`}
       data-model-name={modelName}
       onContextMenu={handleContextMenu}
     >

--- a/webview/components/Toolbar/Toolbar.tsx
+++ b/webview/components/Toolbar/Toolbar.tsx
@@ -76,6 +76,8 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
   const setSearchQuery = useEditorStore((s) => s.setSearchQuery);
   const selectNode = useEditorStore((s) => s.selectNode);
   const setDetailPanelOpen = useEditorStore((s) => s.setDetailPanelOpen);
+  const canvasMode = useEditorStore((s) => s.canvasMode);
+  const setCanvasMode = useEditorStore((s) => s.setCanvasMode);
   const registerSearchFocus = useEditorStore((s) => s.registerSearchFocus);
   const registerAutoLayout = useEditorStore((s) => s.registerAutoLayout);
   // Get current zoom level from React Flow store
@@ -686,6 +688,21 @@ export function Toolbar({ nodes, edges, allExpanded, onExpandAll, onCollapseAll 
             {allExpanded ? '⊟' : '⊞'}
           </button>
         </div>
+
+        {/* Canvas mode — select vs pan */}
+        {!domain?.readOnly && (
+          <div className="toolbar__section">
+            <button
+              className={`toolbar__button toolbar__button--tooltip${canvasMode === 'select' ? ' toolbar__button--active' : ''}`}
+              onClick={() => setCanvasMode(canvasMode === 'select' ? 'pan' : 'select')}
+              data-tooltip={canvasMode === 'select' ? 'Pan Mode' : 'Select Mode'}
+              aria-label="Toggle select mode"
+              aria-pressed={canvasMode === 'select'}
+            >
+              ⬚
+            </button>
+          </div>
+        )}
 
         {/* Discrepancy toggle */}
         {discrepancyOptions.length > 0 && (

--- a/webview/store/editorStore.ts
+++ b/webview/store/editorStore.ts
@@ -160,6 +160,12 @@ export interface EditorState {
   editingColumn: string | null;
   /** Currently selected annotation ID, or null. */
   selectedAnnotation: string | null;
+  /**
+   * Canvas interaction mode.
+   * - 'pan' (default): drag on empty canvas pans the viewport. Shift+drag still rubber-bands.
+   * - 'select': drag on empty canvas draws a rubber-band selection box (no Shift needed) and the cursor is a crosshair.
+   */
+  canvasMode: 'pan' | 'select';
 }
 
 export interface EditorActions {
@@ -266,6 +272,8 @@ export interface EditorActions {
   setEditingColumn: (name: string | null) => void;
   /** Select an annotation (clears model selection). */
   selectAnnotation: (annotationId: string | null) => void;
+  /** Set the canvas interaction mode. */
+  setCanvasMode: (mode: 'pan' | 'select') => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +323,7 @@ export const useEditorStore = create<EditorState & EditorActions>()((set) => ({
   lastSelectedColumn: null,
   editingColumn: null,
   selectedAnnotation: null,
+  canvasMode: 'pan',
 
   // Actions
   setSearchQuery: (query) => set({ searchQuery: query }),
@@ -343,6 +352,9 @@ export const useEditorStore = create<EditorState & EditorActions>()((set) => ({
       ? {
           discrepancyVisible: false, discrepancyCompareStage: null, discrepancyReport: null,
           syncMode: false, syncSelections: {}, manifestStale: false, syncPlanGenerated: null,
+          // Reset canvas mode to pan on stage switch; select mode is short-lived UI intent
+          // and shouldn't persist across a stage change (physical is read-only).
+          canvasMode: 'pan' as const,
         }
       : {}),
   })),
@@ -480,4 +492,6 @@ export const useEditorStore = create<EditorState & EditorActions>()((set) => ({
     lastSelectedColumn: null,
     editingColumn: null,
   }),
+
+  setCanvasMode: (mode) => set({ canvasMode: mode }),
 }));


### PR DESCRIPTION
## Summary
- Adds a persistent **Select Mode** (toolbar `⬚` toggle + `S` keyboard shortcut, `V`/`Escape` to exit) — crosshair cursor, drag on empty canvas rubber-bands a selection without needing Shift.
- Selected tables now show a stage-coloured ring + subtle glow so multi-select is visually obvious (uses existing `--stage-logical` / `--stage-physical` tokens; discrepancy amber wins).
- Fixes a latent bug: the domain-rebuild effect was running on every `onSelectionChange` (because `setSelectedEdges([])` always created a new array reference) and wiping React Flow's rubber-band selection. The effect now preserves the current node selection by reading it from the store directly, avoiding a dep-array loop.
- Shift+click and Shift+drag continue to work unchanged.
- Group-drag already persists correctly — the existing debounced `usePositionPersistence` batches all drag-end events into one `updatePositions` message → one `WorkspaceEdit` → one undo step.

## Test plan
- [ ] Shift+click 2-3 tables → all get blue ring; drag one → group moves together; Cmd+Z → single undo
- [ ] Click toolbar `⬚` or press `S` → cursor becomes crosshair, drag selects tables without Shift
- [ ] Press `V` or `Escape` (twice) → returns to pan mode
- [ ] Switch to Physical stage → toolbar button hides (read-only), mode resets to pan

🤖 Generated with [Claude Code](https://claude.com/claude-code)