### PR TITLE
feat: auto-recover canvas after extension updates

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,15 @@ import { LogicalModelService } from './services/logicalModelService';
 import { MigrationService } from './services/migrationService';
 import { YmlParserService } from './services/ymlParserService';
 import { ModelLibraryTreeProvider, type ModelLibraryNode } from './providers/ModelLibraryTreeProvider';
+import { DOMAIN_EDITOR_VIEW_TYPE, hasOpenDomainCanvas, saveAllAndReload } from './services/recoveryService';
+
+/**
+ * globalState key for the last extension version this host activated under.
+ * If activation sees a different version stored here, the previous extension
+ * host was torn down by an update — any open domain canvas is now orphaned
+ * and the only reliable recovery is a window reload.
+ */
+const LAST_ACTIVATED_VERSION_KEY = 'lastActivatedVersion';
 
 /**
  * Find the dbt project root by searching workspace folders for dbt_project.yml.
@@ -145,8 +154,23 @@ const LAYER_COLOR_OPTIONS = [
   { label: '$(edit) Custom hex color...', value: 'custom' },
 ];
 
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
   console.log('ERD Studio is now active');
+
+  // Auto-recover from extension updates that orphaned an open domain canvas.
+  // VS Code 1.88+ restarts the extension host without a window reload when
+  // an extension version changes — the new host has no message handler bound
+  // for the existing webview, leaving a blank canvas. Detect by comparing
+  // the version we last activated under to the current one. The globalState
+  // update is awaited *before* the reload to prevent a reload loop if the
+  // host crashes mid-recovery.
+  const currentVersion = context.extension.packageJSON.version as string;
+  const previousVersion = context.globalState.get<string>(LAST_ACTIVATED_VERSION_KEY);
+  await context.globalState.update(LAST_ACTIVATED_VERSION_KEY, currentVersion);
+  if (previousVersion && previousVersion !== currentVersion && hasOpenDomainCanvas()) {
+    await saveAllAndReload(`ERD Studio updated to v${currentVersion}`);
+    return;
+  }
 
   const workspaceRoot = findDbtProjectRoot();
   if (!workspaceRoot) {
@@ -392,7 +416,7 @@ export function activate(context: vscode.ExtensionContext): void {
       });
       return treeView;
     })(),
-    vscode.window.registerCustomEditorProvider('dbtSemantic.domainEditor', editorProvider),
+    vscode.window.registerCustomEditorProvider(DOMAIN_EDITOR_VIEW_TYPE, editorProvider),
     vscode.window.registerFileDecorationProvider(decorationProvider),
     vscode.window.registerFileDecorationProvider(layerDecorationProvider),
     modelLibraryProvider,
@@ -429,7 +453,7 @@ export function activate(context: vscode.ExtensionContext): void {
       await vscode.commands.executeCommand(
         'vscode.openWith',
         fileUri,
-        'dbtSemantic.domainEditor',
+        DOMAIN_EDITOR_VIEW_TYPE,
       );
       if (stage === 'physical') {
         editorProvider.switchStageForUri(fileUri, 'physical');
@@ -543,7 +567,7 @@ export function activate(context: vscode.ExtensionContext): void {
         await vscode.commands.executeCommand(
           'vscode.openWith',
           vscode.Uri.file(filePath),
-          'dbtSemantic.domainEditor',
+          DOMAIN_EDITOR_VIEW_TYPE,
         );
       },
     ),
@@ -646,7 +670,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Auto-open renamed domain
         selectorsService.scheduleRegenerate();
-        await vscode.commands.executeCommand('vscode.openWith', newFileUri, 'dbtSemantic.domainEditor');
+        await vscode.commands.executeCommand('vscode.openWith', newFileUri, DOMAIN_EDITOR_VIEW_TYPE);
       },
     ),
     vscode.commands.registerCommand('dbtSemantic.refreshManifest', async () => {

--- a/src/providers/SemanticEditorProvider.ts
+++ b/src/providers/SemanticEditorProvider.ts
@@ -28,6 +28,7 @@ import { LayerService } from '../services/layerService';
 import { SelectorsService } from '../services/selectorsService';
 import { computeNewModelPositions, findOpenPosition } from '../services/positionService';
 import { checkManifestStaleness } from '../services/stalenessService';
+import { saveAllAndReload } from '../services/recoveryService';
 import type { ManifestData } from '../types/manifest';
 import type { YmlData } from '../types/ymlData';
 import type { DiscrepancyReport } from '../types/discrepancy';
@@ -237,6 +238,7 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
           'refreshManifest', 'undo', 'redo', 'updateViewConfig', 'dismissWelcome',
           'viewFile', 'checkManifestStaleness', 'generateSyncPlan', 'runDbtCompile', 'launchClaudeSync',
           'addAnnotation', 'updateAnnotation', 'removeAnnotation', 'updateAnnotationPosition',
+          'requestReload',
         ]);
         if (panel?.activeStage === 'physical' && !NON_MUTATION_TYPES.has(message.type)) {
           return;
@@ -248,6 +250,13 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
         switch (message.type) {
           case 'ready':
             await this.sendDomainData(document, webviewPanel.webview, panelKey);
+            break;
+          case 'requestReload':
+            // Webview detected it was orphaned (e.g. extension update before
+            // activation auto-recovery could fire). Save & reload safely.
+            saveAllAndReload('ERD Studio canvas connection lost').catch(err => {
+              console.error('[ERD Studio] requestReload handling failed:', err);
+            });
             break;
           case 'dismissWelcome':
             await this.context.globalState.update('welcomeDismissed', true);
@@ -2915,9 +2924,29 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
 
   private getHtmlForWebview(webview: vscode.Webview): string {
     const nonce = crypto.randomBytes(16).toString('base64');
-    const scriptUri = webview.asWebviewUri(
-      vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview.js'),
-    );
+    const scriptOnDisk = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview.js');
+
+    // Worst case: an extension update removed the previous version's directory
+    // before this panel was reattached. The cached <script src> would 404 and
+    // leave a blank canvas with no JS to surface the problem. Render a static
+    // fallback that prompts the user to reload.
+    if (!fs.existsSync(scriptOnDisk.fsPath)) {
+      return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ERD Studio</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline';">
+</head>
+<body style="font-family: var(--vscode-font-family, sans-serif); padding: 24px; color: var(--vscode-foreground);">
+  <h2 style="margin-top: 0;">ERD Studio was updated</h2>
+  <p>This canvas can't render until the window reloads to pick up the new extension files.</p>
+  <p>Run <strong>Developer: Reload Window</strong> from the Command Palette (⌘⇧P / Ctrl+Shift+P).</p>
+</body>
+</html>`;
+    }
+
+    const scriptUri = webview.asWebviewUri(scriptOnDisk);
     const styleUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview.css'),
     );

--- a/src/services/recoveryService.ts
+++ b/src/services/recoveryService.ts
@@ -1,0 +1,69 @@
+/**
+ * Recovery utilities for the "extension update orphaned a webview" case.
+ *
+ * VS Code 1.88+ restarts the extension host without a window reload when an
+ * extension version changes. The new host has no message handler bound for
+ * existing custom-editor webviews, so any open canvas becomes orphaned. The
+ * only true fix is a window reload — these helpers do that gracefully without
+ * losing the user's unsaved work.
+ */
+
+import * as vscode from 'vscode';
+
+/**
+ * Custom editor viewType for the domain canvas. Single source of truth — keep
+ * in sync with the `customEditors` contribution in package.json. Per CLAUDE.md
+ * this identifier is part of the legacy public API and must not be renamed.
+ */
+export const DOMAIN_EDITOR_VIEW_TYPE = 'dbtSemantic.domainEditor';
+
+/**
+ * True when at least one editor tab is showing a domain canvas. Used to
+ * decide whether a window reload is actually needed: if no canvas is open,
+ * an extension update doesn't strand the user and we shouldn't bother them.
+ */
+export function hasOpenDomainCanvas(): boolean {
+  return vscode.window.tabGroups.all.some(group =>
+    group.tabs.some(tab =>
+      tab.input instanceof vscode.TabInputCustom &&
+      tab.input.viewType === DOMAIN_EDITOR_VIEW_TYPE,
+    ),
+  );
+}
+
+/**
+ * Save all dirty editors, then reload the window. saveAll runs first so no
+ * work is lost; if it fails the user is prompted to handle it manually rather
+ * than silently risking data loss.
+ *
+ * @param reason — short user-facing phrase shown in the status bar before the
+ *   reload, e.g. "ERD Studio updated to v0.6.33".
+ */
+export async function saveAllAndReload(reason: string): Promise<void> {
+  void vscode.window.setStatusBarMessage(
+    `$(sync~spin) ${reason} — saving your work and reloading…`,
+    5000,
+  );
+  try {
+    await vscode.commands.executeCommand('workbench.action.files.saveAll');
+  } catch (err) {
+    console.error('[ERD Studio] saveAll command threw:', err);
+  }
+
+  // saveAll returns void and won't surface per-file failures (read-only files,
+  // save validators vetoing, etc.). Re-check dirty state and gate the reload
+  // behind an explicit confirmation if anything is still unsaved.
+  const stillDirty = vscode.workspace.textDocuments.filter(d => d.isDirty && !d.isUntitled);
+  if (stillDirty.length > 0) {
+    const choice = await vscode.window.showWarningMessage(
+      `${stillDirty.length} file(s) could not be saved. Reload anyway? Unsaved changes will be lost.`,
+      'Reload Anyway',
+      'Cancel',
+    );
+    if (choice !== 'Reload Anyway') return;
+  }
+
+  // Brief delay so the status bar message is visible before the reload kicks in.
+  await new Promise(resolve => setTimeout(resolve, 600));
+  await vscode.commands.executeCommand('workbench.action.reloadWindow');
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -433,6 +433,16 @@ export interface ViewFileMessage {
   type: 'viewFile';
 }
 
+/**
+ * Request the extension to save all dirty editors and reload the window.
+ * Sent by the webview when it detects it has become orphaned (e.g. after an
+ * extension update tore down the previous extension host instance and the new
+ * one has no message handler bound for this panel).
+ */
+export interface RequestReloadMessage {
+  type: 'requestReload';
+}
+
 // ---------------------------------------------------------------------------
 // Webview → Extension: Sync reconciliation messages
 // ---------------------------------------------------------------------------
@@ -562,6 +572,7 @@ export type WebviewMessage =
   | ToggleDiscrepancyMessage
   | ReorderColumnsMessage
   | ViewFileMessage
+  | RequestReloadMessage
   | CheckManifestStalenessMessage
   | GenerateSyncPlanMessage
   | RunDbtCompileMessage

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -30,6 +30,7 @@ export const window = {
   showErrorMessage: async () => undefined,
   showInputBox: async () => undefined,
   showQuickPick: async () => undefined,
+  setStatusBarMessage: (_message: string, _hideAfterTimeout?: number) => ({ dispose: () => {} }),
   createOutputChannel: () => ({
     appendLine: () => {},
     show: () => {},
@@ -38,7 +39,13 @@ export const window = {
   registerTreeDataProvider: () => ({ dispose: () => {} }),
   registerCustomEditorProvider: () => ({ dispose: () => {} }),
   createTreeView: () => ({ dispose: () => {} }),
+  tabGroups: { all: [] as Array<{ tabs: Array<{ input: unknown }> }> },
 };
+
+/** Minimal mock of vscode.TabInputCustom for the recovery service. */
+export class TabInputCustom {
+  constructor(public readonly uri: unknown, public readonly viewType: string) {}
+}
 
 export const commands = {
   registerCommand: () => ({ dispose: () => {} }),

--- a/test/unit/recoveryService.test.ts
+++ b/test/unit/recoveryService.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+import {
+  DOMAIN_EDITOR_VIEW_TYPE,
+  hasOpenDomainCanvas,
+  saveAllAndReload,
+} from '../../src/services/recoveryService';
+
+interface MutableTabGroups {
+  all: Array<{ tabs: Array<{ input: unknown }> }>;
+}
+
+const mockTabGroups = (vscode.window as unknown as { tabGroups: MutableTabGroups }).tabGroups;
+
+const setOpenTabs = (tabs: Array<{ input: unknown }>) => {
+  mockTabGroups.all = [{ tabs }];
+};
+
+describe('recoveryService', () => {
+  beforeEach(() => {
+    setOpenTabs([]);
+    (vscode.workspace as unknown as { textDocuments: unknown[] }).textDocuments = [];
+    vi.restoreAllMocks();
+  });
+
+  describe('hasOpenDomainCanvas', () => {
+    it('returns false when no tabs are open', () => {
+      expect(hasOpenDomainCanvas()).toBe(false);
+    });
+
+    it('returns false when only non-canvas tabs are open', () => {
+      setOpenTabs([{ input: { uri: { fsPath: '/foo.ts' } } }]);
+      expect(hasOpenDomainCanvas()).toBe(false);
+    });
+
+    it('returns true when a domain canvas tab is open', () => {
+      const tabInput = new vscode.TabInputCustom({ fsPath: '/dom.json' }, DOMAIN_EDITOR_VIEW_TYPE);
+      setOpenTabs([{ input: tabInput }]);
+      expect(hasOpenDomainCanvas()).toBe(true);
+    });
+
+    it('ignores TabInputCustom entries with a different viewType', () => {
+      const tabInput = new vscode.TabInputCustom({ fsPath: '/img.png' }, 'imagePreview.previewEditor');
+      setOpenTabs([{ input: tabInput }]);
+      expect(hasOpenDomainCanvas()).toBe(false);
+    });
+  });
+
+  describe('saveAllAndReload', () => {
+    it('runs saveAll then reloadWindow when nothing is dirty after save', async () => {
+      const exec = vi.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
+
+      await saveAllAndReload('test reason');
+
+      expect(exec).toHaveBeenCalledWith('workbench.action.files.saveAll');
+      expect(exec).toHaveBeenCalledWith('workbench.action.reloadWindow');
+      // saveAll must precede reload — never reload before saving.
+      const calls = exec.mock.calls.map(c => c[0]);
+      expect(calls.indexOf('workbench.action.files.saveAll'))
+        .toBeLessThan(calls.indexOf('workbench.action.reloadWindow'));
+    });
+
+    it('still attempts reload if saveAll throws (errors are swallowed)', async () => {
+      const exec = vi.spyOn(vscode.commands, 'executeCommand').mockImplementation(async (cmd: string) => {
+        if (cmd === 'workbench.action.files.saveAll') throw new Error('boom');
+        return undefined;
+      });
+      const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await saveAllAndReload('test reason');
+
+      expect(exec).toHaveBeenCalledWith('workbench.action.reloadWindow');
+      expect(consoleErr).toHaveBeenCalled();
+    });
+
+    it('prompts before reloading when documents remain dirty after save', async () => {
+      (vscode.workspace as unknown as { textDocuments: unknown[] }).textDocuments = [
+        { isDirty: true, isUntitled: false },
+      ];
+      const exec = vi.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
+      const warn = vi.spyOn(vscode.window, 'showWarningMessage')
+        .mockResolvedValue('Reload Anyway' as never);
+
+      await saveAllAndReload('test reason');
+
+      expect(warn).toHaveBeenCalled();
+      expect(exec).toHaveBeenCalledWith('workbench.action.reloadWindow');
+    });
+
+    it('aborts the reload when the user cancels the dirty-files prompt', async () => {
+      (vscode.workspace as unknown as { textDocuments: unknown[] }).textDocuments = [
+        { isDirty: true, isUntitled: false },
+      ];
+      const exec = vi.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
+      vi.spyOn(vscode.window, 'showWarningMessage').mockResolvedValue('Cancel' as never);
+
+      await saveAllAndReload('test reason');
+
+      expect(exec).toHaveBeenCalledWith('workbench.action.files.saveAll');
+      expect(exec).not.toHaveBeenCalledWith('workbench.action.reloadWindow');
+    });
+
+    it('ignores untitled dirty documents (they are not real saved-file losses)', async () => {
+      (vscode.workspace as unknown as { textDocuments: unknown[] }).textDocuments = [
+        { isDirty: true, isUntitled: true },
+      ];
+      const exec = vi.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
+      const warn = vi.spyOn(vscode.window, 'showWarningMessage');
+
+      await saveAllAndReload('test reason');
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(exec).toHaveBeenCalledWith('workbench.action.reloadWindow');
+    });
+  });
+});

--- a/webview/App.tsx
+++ b/webview/App.tsx
@@ -47,6 +47,7 @@ import { Legend } from './components/Legend/Legend';
 import { DiscrepancyPanel } from './components/DiscrepancyPanel/DiscrepancyPanel';
 import { WelcomeModal } from './components/WelcomeModal/WelcomeModal';
 import { SyncMergeModal } from './components/SyncMergeModal/SyncMergeModal';
+import { ReconnectOverlay } from './components/ReconnectOverlay/ReconnectOverlay';
 import { transformDomain } from './lib/graphTransformer';
 import { stageNodeColor } from './lib/stageColors';
 import type { ModelFlowNode, FkFlowEdge, AnnotationFlowNode, AnnotationFlowEdge } from './types/graph';
@@ -268,6 +269,25 @@ function EditorCanvas() {
   );
 
   useMessageBus(onMessage, /* sendReadyOnMount */ true);
+
+  // Detect orphaned-canvas state: if `domainLoaded` doesn't arrive within
+  // the boot grace period, the extension host probably can't reach this
+  // panel (typically because it was updated/restarted while the panel was
+  // open). Activation-time auto-recovery in the host should usually fix
+  // this before the overlay ever shows — this is a safety net for edge
+  // cases like extension disable/enable mid-session.
+  const [showReconnectOverlay, setShowReconnectOverlay] = useState(false);
+  useEffect(() => {
+    if (domain) return;
+    const overlayTimer = window.setTimeout(() => {
+      setShowReconnectOverlay(true);
+    }, 5000);
+    return () => clearTimeout(overlayTimer);
+  }, [domain]);
+
+  const handleReconnect = useCallback(() => {
+    vscode.postMessage({ type: 'requestReload' });
+  }, [vscode]);
 
   // Unified keyboard shortcut handler (Escape, Delete/Backspace, Ctrl+F)
   useEffect(() => {
@@ -876,9 +896,12 @@ function EditorCanvas() {
 
   if (!domain) {
     return (
-      <div className="editor-message">
-        <p>Loading domain&hellip;</p>
-      </div>
+      <>
+        <div className="editor-message">
+          <p>Loading domain&hellip;</p>
+        </div>
+        {showReconnectOverlay && <ReconnectOverlay onReload={handleReconnect} />}
+      </>
     );
   }
 

--- a/webview/components/ReconnectOverlay/ReconnectOverlay.css
+++ b/webview/components/ReconnectOverlay/ReconnectOverlay.css
@@ -1,0 +1,60 @@
+.reconnect-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.reconnect-overlay__panel {
+  max-width: 420px;
+  padding: 20px 24px;
+
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-left: 3px solid var(--warning-fg);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+
+  color: var(--editor-fg);
+  font-size: 13px;
+}
+
+.reconnect-overlay__title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.reconnect-overlay__body {
+  margin: 0 0 16px;
+  line-height: 1.5;
+  opacity: 0.9;
+}
+
+.reconnect-overlay__button {
+  padding: 6px 14px;
+
+  background: var(--button-bg);
+  color: var(--button-fg);
+  border: none;
+  border-radius: 3px;
+
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+
+  transition: background 0.1s ease;
+}
+
+.reconnect-overlay__button:hover {
+  background: var(--button-hover-bg);
+}
+
+.reconnect-overlay__button:focus {
+  outline: 1px solid var(--focus-border);
+  outline-offset: 1px;
+}

--- a/webview/components/ReconnectOverlay/ReconnectOverlay.tsx
+++ b/webview/components/ReconnectOverlay/ReconnectOverlay.tsx
@@ -1,0 +1,32 @@
+/**
+ * ReconnectOverlay — surfaces an orphaned-canvas state to the user.
+ *
+ * Renders when the webview has sent `ready` but received no `domainLoaded`
+ * within the boot grace period. The most common cause is an extension update
+ * that tore down the previous host instance after this panel was already
+ * open, leaving no message handler bound. Activation-time auto-recovery
+ * should usually fix this before the overlay appears; this is the safety net
+ * for cases where it didn't (e.g. the extension was disabled and re-enabled).
+ */
+
+import './ReconnectOverlay.css';
+
+export interface ReconnectOverlayProps {
+  onReload: () => void;
+}
+
+export function ReconnectOverlay({ onReload }: ReconnectOverlayProps) {
+  return (
+    <div className="reconnect-overlay" role="alert">
+      <div className="reconnect-overlay__panel">
+        <h3 className="reconnect-overlay__title">Canvas disconnected</h3>
+        <p className="reconnect-overlay__body">
+          ERD Studio looks like it was updated or restarted. Reload the window to reconnect — your work will be saved first.
+        </p>
+        <button className="reconnect-overlay__button" onClick={onReload}>
+          Reload Window
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Detect at activation time when the extension version changed while a domain canvas is open and trigger a save-then-reload flow automatically — no more blank canvases or full VS Code restarts after an update
- Webview safety net: render a "Canvas disconnected" overlay if `domainLoaded` never arrives within 5s (covers extension disable/enable mid-session)
- Static HTML fallback when `dist/webview.js` is missing post-update, prompting the user to reload manually
- Save-before-reload preserves unsaved work; if anything fails to save the user is asked to confirm before the window reloads

## Test plan
- [x] Unit tests for `recoveryService` (9 tests): save-before-reload ordering, swallowed save errors, dirty-file confirmation, cancel aborts, untitled-doc exclusion, `hasOpenDomainCanvas` detection
- [x] Full suite green (364/364)
- [x] Manual: extension dev host loads, canvas renders correctly with all changes in place
- [ ] End-to-end (manual): bump `package.json` version, rebuild, run "Developer: Restart Extension Host" with `showcase.json` open — verify auto-recovery fires and canvas re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)