### PR TITLE
feat: delete multiple selected items at once with Delete key

### DIFF
--- a/src/providers/SemanticEditorProvider.ts
+++ b/src/providers/SemanticEditorProvider.ts
@@ -340,6 +340,14 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
             }
             break;
           }
+          case 'removeModels': {
+            const payload = (message as { payload?: { modelNames: string[] } }).payload;
+            if (payload && payload.modelNames.length > 0) {
+              await this.queueEdit(panelKey, () =>
+                this.handleRemoveModels(document, webviewPanel.webview, payload, activeStage));
+            }
+            break;
+          }
           case 'removeRelationship': {
             const payload = (message as { payload?: { fromModel: string; fromColumn: string; toModel: string; toColumn: string } }).payload;
             if (payload) {
@@ -1646,81 +1654,116 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
     }
   }
 
+  /** Single-model removal — thin wrapper over the batch handler. */
   private async handleRemoveModel(
     document: vscode.TextDocument,
     webview: vscode.Webview,
     payload: { modelName: string },
     stage: 'logical',
   ): Promise<void> {
+    return this.handleRemoveModels(
+      document,
+      webview,
+      { modelNames: [payload.modelName] },
+      stage,
+    );
+  }
+
+  /**
+   * Batch-remove one or more models in a single document edit.
+   * Cascades all relationships referencing any listed model and removes their
+   * viewConfig positions. Produces one WorkspaceEdit (one undo step, one save)
+   * regardless of how many models are deleted.
+   *
+   * In V5, after the domain is updated, prompts the user once to optionally
+   * delete the underlying logical-models/*.yml files for any names that exist
+   * on disk. Singular/plural copy is chosen automatically.
+   */
+  private async handleRemoveModels(
+    document: vscode.TextDocument,
+    webview: vscode.Webview,
+    payload: { modelNames: string[] },
+    stage: 'logical',
+  ): Promise<void> {
+    const namesSet = new Set(payload.modelNames);
+    if (namesSet.size === 0) return;
+    const isSingle = namesSet.size === 1;
+    const errorLabel = isSingle ? 'model' : 'models';
+
     try {
       const text = document.getText();
       const parsed = JSON.parse(text) as Record<string, unknown>;
-      const section = this.getStageSection(parsed, stage);
 
-      // V5: remove reference from domain + ask about deleting model file
       if (this.isDomainV5(parsed)) {
-        // Remove reference, relationships, and position from domain
         const success = await this.applyDomainEdit(
           document,
           (sec, p) => {
-            const names = (sec.models ?? []) as string[];
-            const idx = names.indexOf(payload.modelName);
-            if (idx !== -1) names.splice(idx, 1);
+            const models = (sec.models ?? []) as string[];
+            sec.models = models.filter((name) => !namesSet.has(name));
 
             const relationships = (sec.relationships ?? []) as Array<Record<string, unknown>>;
             sec.relationships = relationships.filter(
-              (rel) => rel.fromModel !== payload.modelName && rel.toModel !== payload.modelName,
+              (rel) =>
+                !namesSet.has(rel.fromModel as string) &&
+                !namesSet.has(rel.toModel as string),
             );
 
             const vc = (p.viewConfig ?? {}) as Record<string, unknown>;
             const positions = (vc.positions ?? {}) as Record<string, unknown>;
-            delete positions[payload.modelName];
+            for (const name of namesSet) delete positions[name];
           },
           { refreshWebview: true, webview, stage },
         );
 
         if (!success) {
-          webview.postMessage({ type: 'error', payload: { message: 'Failed to remove model.' } });
+          webview.postMessage({ type: 'error', payload: { message: `Failed to remove ${errorLabel}.` } });
           return;
         }
 
         this.selectorsService.scheduleRegenerate();
 
-        // Ask: remove from domain only, or delete model file entirely?
-        if (this.logicalModelService.modelExists(payload.modelName)) {
-          void vscode.window.showInformationMessage(
-            `Model "${payload.modelName}" removed from this domain. Delete the model file entirely?`,
-            'Delete Model File',
-            'Keep File',
-          ).then((choice) => {
-            if (choice === 'Delete Model File') {
-              this.logicalModelService.deleteModel(payload.modelName);
-              vscode.window.showInformationMessage(`Deleted logical-models/${payload.modelName}.yml`);
-            }
-          });
+        // Single batched prompt for any underlying .yml files.
+        const filesToOffer = [...namesSet].filter((name) =>
+          this.logicalModelService.modelExists(name),
+        );
+        if (filesToOffer.length > 0) {
+          const fileIsSingle = filesToOffer.length === 1;
+          const prompt = fileIsSingle
+            ? `Model "${filesToOffer[0]}" removed from this domain. Delete the model file entirely?`
+            : `${filesToOffer.length} models removed from this domain. Delete their model files entirely?`;
+          const deleteLabel = fileIsSingle ? 'Delete Model File' : 'Delete Model Files';
+          const keepLabel = fileIsSingle ? 'Keep File' : 'Keep Files';
+          void vscode.window
+            .showInformationMessage(prompt, deleteLabel, keepLabel)
+            .then((choice) => {
+              if (choice !== deleteLabel) return;
+              for (const name of filesToOffer) {
+                this.logicalModelService.deleteModel(name);
+              }
+              const summary = fileIsSingle
+                ? `Deleted logical-models/${filesToOffer[0]}.yml`
+                : `Deleted ${filesToOffer.length} model files`;
+              vscode.window.showInformationMessage(summary);
+            });
         }
         return;
       }
 
       // V4: legacy inline path
+      const section = this.getStageSection(parsed, stage);
       const models = (section.models ?? []) as Array<Record<string, unknown>>;
-      const modelIndex = models.findIndex((m) => m.name === payload.modelName);
-      if (modelIndex === -1) {
-        webview.postMessage({ type: 'error', payload: { message: `Model "${payload.modelName}" not found.` } });
-        return;
-      }
-
-      models.splice(modelIndex, 1);
-      section.models = models;
+      section.models = models.filter((m) => !namesSet.has(m.name as string));
 
       const relationships = (section.relationships ?? []) as Array<Record<string, unknown>>;
       section.relationships = relationships.filter(
-        (rel) => rel.fromModel !== payload.modelName && rel.toModel !== payload.modelName,
+        (rel) =>
+          !namesSet.has(rel.fromModel as string) &&
+          !namesSet.has(rel.toModel as string),
       );
 
       const viewConfig = (parsed.viewConfig ?? {}) as Record<string, unknown>;
       const positions = (viewConfig.positions ?? {}) as Record<string, unknown>;
-      delete positions[payload.modelName];
+      for (const name of namesSet) delete positions[name];
       viewConfig.positions = positions;
       parsed.viewConfig = viewConfig;
 
@@ -1742,13 +1785,13 @@ export class SemanticEditorProvider implements vscode.CustomTextEditorProvider {
         }
       } else {
         this.pendingUpdates.delete(document.uri.toString());
-        webview.postMessage({ type: 'error', payload: { message: 'Failed to remove model.' } });
+        webview.postMessage({ type: 'error', payload: { message: `Failed to remove ${errorLabel}.` } });
       }
     } catch (err) {
       this.pendingUpdates.delete(document.uri.toString());
       const message = err instanceof Error ? err.message : String(err);
-      console.error(`[SemanticEditorProvider] Remove model failed: ${message}`);
-      webview.postMessage({ type: 'error', payload: { message: `Failed to remove model: ${message}` } });
+      console.error(`[SemanticEditorProvider] Remove ${errorLabel} failed: ${message}`);
+      webview.postMessage({ type: 'error', payload: { message: `Failed to remove ${errorLabel}: ${message}` } });
     }
   }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -195,6 +195,18 @@ export interface RemoveModelMessage {
 }
 
 /**
+ * Request to remove multiple models from the domain in a single edit.
+ * Cascades all relationships referencing any of the listed models and
+ * cleans up their viewConfig positions. One WorkspaceEdit, one undo step.
+ */
+export interface RemoveModelsMessage {
+  type: 'removeModels';
+  payload: {
+    modelNames: string[];
+  };
+}
+
+/**
  * Request to remove an FK relationship.
  * Identity is the composite key: (fromModel, fromColumn, toModel, toColumn).
  */
@@ -552,6 +564,7 @@ export type WebviewMessage =
   | AddRelationshipMessage
   | RenameModelMessage
   | RemoveModelMessage
+  | RemoveModelsMessage
   | RemoveRelationshipMessage
   | UpdateRelationshipMessage
   | EditRelationshipMessage

--- a/webview/App.tsx
+++ b/webview/App.tsx
@@ -451,6 +451,64 @@ function EditorCanvas() {
       if (e.key === 'Delete' || e.key === 'Backspace') {
         if (!domain || domain.readOnly) return;
 
+        // Priority -1: Multi-select delete (2+ items selected) — immediate, no confirmation.
+        // Read React Flow's selection from the nodes array (source of truth for multi-select).
+        const allSelectedNodes = useEditorStore.getState().nodes.filter((n) => n.selected);
+        const selectedModelNames = allSelectedNodes
+          .filter((n): n is ModelFlowNode => n.type === 'model')
+          .map((n) => n.data.modelName);
+        // graphTransformer namespaces annotation node IDs as `annotation-${id}` —
+        // unwrap to the raw domain ID for the wire protocol.
+        const selectedAnnotationIds = allSelectedNodes
+          .filter((n): n is AnnotationFlowNode => n.type === 'annotation')
+          .map((n) => n.data.annotationId);
+        const totalSelected =
+          selectedModelNames.length + selectedAnnotationIds.length + selectedEdges.length;
+
+        if (totalSelected >= 2) {
+          e.preventDefault();
+
+          if (selectedModelNames.length > 0) {
+            vscode.postMessage({
+              type: 'removeModels',
+              payload: { modelNames: selectedModelNames },
+            });
+          }
+
+          for (const id of selectedAnnotationIds) {
+            vscode.postMessage({ type: 'removeAnnotation', payload: { id } });
+          }
+
+          // Skip edges that the model batch will cascade.
+          for (const edgeId of selectedEdges) {
+            const rel = domain.relationships.find(
+              (r) =>
+                `fk-${r.fromModel}-${r.fromColumn}-${r.toModel}-${r.toColumn}` === edgeId,
+            );
+            if (
+              !rel ||
+              selectedModelNames.includes(rel.fromModel) ||
+              selectedModelNames.includes(rel.toModel)
+            ) {
+              continue;
+            }
+            vscode.postMessage({
+              type: 'removeRelationship',
+              payload: {
+                fromModel: rel.fromModel,
+                fromColumn: rel.fromColumn,
+                toModel: rel.toModel,
+                toColumn: rel.toColumn,
+              },
+            });
+          }
+
+          selectNode(null);
+          selectAnnotation(null);
+          setSelectedEdges([]);
+          return;
+        }
+
         // Priority 0: Delete selected annotation (no confirmation — undo exists)
         if (selectedAnnotation) {
           e.preventDefault();
@@ -936,6 +994,7 @@ function EditorCanvas() {
         selectionOnDrag={(selectModeActive || shiftHeld) && !domain.readOnly}
         selectionKeyCode={null}
         multiSelectionKeyCode="Shift"
+        deleteKeyCode={null}
         proOptions={{ hideAttribution: true }}
       >
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />


### PR DESCRIPTION
## Summary
- Multi-select on the canvas (shift-click or rubber-band drag), then Delete removes all selected items in one go — models, annotations, and standalone edges
- New `removeModels` batched message: one `WorkspaceEdit`, one save, one undo step for the entire batch
- Single batched VS Code prompt for "delete N model files?" replaces N back-to-back popups
- `handleRemoveModel` refactored to delegate into the batch handler (~80 lines of duplication removed)
- `deleteKeyCode={null}` on ReactFlow disables its built-in delete handler, which was racing our window-level handler and clearing selection

## Test plan
- [ ] Shift-click 3+ models, press Delete — all disappear, single undo restores them
- [ ] Rubber-band-drag select (S key or shift-drag) over a region, Delete — same
- [ ] Single-node click + Delete still triggers the DetailPanel two-step confirm (unchanged)
- [ ] Multi-select that includes annotations and edges — all delete together
- [ ] In V5 domains, "delete N model files?" prompt appears once with correct singular/plural copy
- [ ] Physical (read-only) stage rejects multi-delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)