### PR TITLE
chore: sync package.json to marketplace v0.6.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "erd-studio",
   "displayName": "ERD Studio",
   "description": "Visual ERD designer for dbt projects. Design your data warehouse across two stages — Logical (columns, types, FK design) and Physical (read-only manifest view) — with cross-stage discrepancy comparison.",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "publisher": "liamwynne",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## Summary
- Marketplace already has v0.6.40 published. Local package.json was at 0.6.39, causing the previous deploy run on PR #43 to fail with "version already exists" when it tried to bump 0.6.39 → 0.6.40.
- Fast-forward package.json to 0.6.40 so the next auto-deploy bumps to 0.6.41 and publishes cleanly.

## Test plan
- [ ] CI passes
- [ ] Post-merge deploy publishes v0.6.41 to marketplace successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)