### PR TITLE
docs: surface open source presence in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@
   <a href="https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio"><img src="https://vsmarketplacebadges.dev/version-short/liamwynne.erd-studio.svg" alt="VS Marketplace Version" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio"><img src="https://vsmarketplacebadges.dev/installs-short/liamwynne.erd-studio.svg" alt="Installs" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=liamwynne.erd-studio"><img src="https://vsmarketplacebadges.dev/rating-short/liamwynne.erd-studio.svg" alt="Rating" /></a>
-  <img src="https://img.shields.io/badge/license-MIT-0078d4" alt="License: MIT" />
+  <a href="https://github.com/liam-machine/erd-studio"><img src="https://img.shields.io/github/stars/liam-machine/erd-studio?style=flat&logo=github&label=Star&color=0078d4" alt="GitHub stars" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-0078d4" alt="License: MIT" /></a>
+</p>
+
+<p align="center">
+  <sub><em>Free and open source — built in the open on <a href="https://github.com/liam-machine/erd-studio">GitHub</a>. Issues, PRs, and stars welcome.</em></sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adds the canonical GitHub "this is open source" signals to the README header without making the page shouty about it.

## Changes

- **GitHub stars badge** in the existing badge row, linking to the repo. Styled `flat` + VS Code blue (`#0078d4`) to match the marketplace badges already there.
- **MIT license badge → clickable link to `LICENSE`** (was a static image).
- **Small italic sub-line** under the badge row: *"Free and open source — built in the open on GitHub. Issues, PRs, and stars welcome."*

Body copy on line ~36 ("free and open source alternative") and footer mention are left as-is — each says it a different way.

## Why

The README already said "open source" three times, but none of them were the top-of-fold signal readers scan for. The badge row was marketplace-only; nothing hinted at the GitHub presence until you reached the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)