### PR TITLE
fix(deploy): keep release scratch files out of the published package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,12 +71,17 @@ jobs:
       # with "version already exists".
       - name: Determine next version
         run: |
-          if ! npx @vscode/vsce show liamwynne.erd-studio --json > marketplace.json 2> vsce-show.err; then
+          # Write scratch files under RUNNER_TEMP, never the working tree: this
+          # step runs before `vsce package`, so anything left in the repo root
+          # ships to users (v0.6.47 went out carrying marketplace.json).
+          SHOW_JSON="${RUNNER_TEMP}/marketplace.json"
+          SHOW_ERR="${RUNNER_TEMP}/vsce-show.err"
+          if ! npx @vscode/vsce show liamwynne.erd-studio --json > "$SHOW_JSON" 2> "$SHOW_ERR"; then
             echo "::warning::vsce show failed; falling back to package.json version"
-            cat vsce-show.err
-            echo '{}' > marketplace.json
+            cat "$SHOW_ERR"
+            echo '{}' > "$SHOW_JSON"
           fi
-          NEW_VERSION=$(node scripts/release.mjs next-version --marketplace-json marketplace.json)
+          NEW_VERSION=$(node scripts/release.mjs next-version --marketplace-json "$SHOW_JSON")
           npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           echo "NEW_VERSION=${NEW_VERSION}" >> "$GITHUB_ENV"
           echo "Releasing v${NEW_VERSION}"
@@ -113,4 +118,13 @@ jobs:
           AZURE_PAT: ${{ secrets.AZURE_PAT }}
         run: |
           npx @vscode/vsce package --no-dependencies -o erd-studio.vsix
+          # CI's file-list gate only sees the PR checkout; this job creates
+          # files of its own, so assert the real published contents here too.
+          npx @vscode/vsce ls --no-dependencies > vsce-files.txt
+          COUNT=$(wc -l < vsce-files.txt | tr -d ' ')
+          echo "Publishing ${COUNT} files:"; cat vsce-files.txt
+          if [ "$COUNT" -gt 60 ]; then
+            echo "::error::vsce would publish ${COUNT} files (limit 60) — check .vscodeignore and this job's scratch files"
+            exit 1
+          fi
           npx @vscode/vsce publish --packagePath erd-studio.vsix --pat "$AZURE_PAT"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -41,6 +41,10 @@ media/demo.gif
 dev-preview.html
 .worktrees/**
 *.vsix
+# Scratch files the deploy workflow creates next to package.json
+marketplace.json
+vsce-show.err
+vsce-files.txt
 .DS_Store
 **/.DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the ERD Studio extension.
 The `Unreleased` heading below is renamed to the released version by the deploy workflow
 (`scripts/release.mjs changelog`). Add user-facing notes under it as part of each PR.
 
+## Unreleased
+
+### Fixed
+
+- **Published package no longer carries deploy scratch files.** v0.6.47 shipped with `marketplace.json` (147 KB of marketplace metadata) and `vsce-show.err` inside the extension, because the deploy job wrote them next to `package.json` before packaging. They now go to the runner's temp directory, `.vscodeignore` excludes them as a second guard, and the deploy job asserts the packaged file list the same way CI does.
+
 ## 0.6.47 — 2026-09-07
 
 ### Added


### PR DESCRIPTION
v0.6.47 shipped with two files that should never have left the build machine:

```
extension/marketplace.json  [146.68 KB]
extension/vsce-show.err     [0.36 KB]
```

The `Determine next version` step writes both next to `package.json`, and it runs *before* `vsce package`, so they were swept into the `.vsix`. CI's file-list gate could not catch this because those files only exist during a deploy, never in a PR checkout.

**Fix, in three layers:**

1. Write the scratch files to `$RUNNER_TEMP` so they are never in the working tree.
2. Add them to `.vscodeignore` as a second guard.
3. Assert the packaged file list in the deploy job too, not just CI — so the published contents are checked where they are actually produced.

Verified by creating all three files in the working tree and confirming `vsce ls --no-dependencies` still reports 12 files with none of them included.

No functional change to the extension. This is a packaging hygiene fix; users on 0.6.47 have a 147 KB metadata file sitting unused in their extension folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAdtvNxRCP3xLnrFx3wAtu